### PR TITLE
Improve finger homing

### DIFF
--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -338,6 +338,7 @@ public:
         }
         return positions;
     }
+
     /**
      * @brief Get the measured joint velocities.
      * 

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -155,13 +155,13 @@ protected:
         /// torque limitation in the motor this would be very unsafe
 
         //! Max. number of steps when searching for the encoder indices.
-        const uint32_t MAX_STEPS_SEARCH_INDEX = 1000;
+        constexpr uint32_t MAX_STEPS_SEARCH_INDEX = 1000;
         //! Min. number of steps when moving to the end stop.
-        const uint32_t MIN_STEPS_MOVE_TO_END_STOP = 1000;
+        constexpr uint32_t MIN_STEPS_MOVE_TO_END_STOP = 1000;
         //! Size of the window when computing average velocity.
-        const uint32_t SIZE_VELOCITY_WINDOW = 100;
+        constexpr uint32_t SIZE_VELOCITY_WINDOW = 100;
         //! Velocity limit at which the joints are considered to be stopped.
-        const double STOP_VELOCITY = 0.001;
+        constexpr double STOP_VELOCITY = 0.001;
 
         static_assert(MIN_STEPS_MOVE_TO_END_STOP > SIZE_VELOCITY_WINDOW,
                       "MIN_STEPS_MOVE_TO_END_STOP has to be bigger than"
@@ -291,10 +291,10 @@ protected:
         /// which is maybe not the greatest idea. without the velocity and
         /// torque limitation in the motor this would be very unsafe
 
-        const double TORQUE_RATIO = 0.6;
-        const double CONTROL_GAIN_KP = 0.4;
-        const double CONTROL_GAIN_KD = 0.0025;
-        const double MOVE_TIMEOUT = 2000;
+        constexpr double TORQUE_RATIO = 0.6;
+        constexpr double CONTROL_GAIN_KP = 0.4;
+        constexpr double CONTROL_GAIN_KD = 0.0025;
+        constexpr double MOVE_TIMEOUT = 2000;
 
         // Offset between home position and zero.  Defined such that the zero
         // position is at the negative end stop (for compatibility with old

--- a/src/blmc_joint_module.cpp
+++ b/src/blmc_joint_module.cpp
@@ -37,7 +37,7 @@ void BlmcJointModule::set_torque(const double& desired_torque)
     if(std::fabs(desired_current) > max_current_)
     {
         std::cout << "something went wrong, it should never happen"
-                      "that desired_current > "
+                     " that desired_current > "
                   << max_current_
                   << ". desired_current: "
                   << desired_current


### PR DESCRIPTION
# Description

Extend the homing (or "calibration") method of the "real finger" to not
use the end stops as zero position but from the end stops go back to the
closest encoder index. This should improve accuracy as the actual joint
positions when pushing against the end stop can vary a bit while the
encoder index should always be at exactly the same position.

Complete procedure now:

1. Move a bit in positive direction until all encoder indices are found
(for most cases this is not really necessary but is needed to catch
some corner cases)
2. Move in negative direction until the joints are stopped by the end
stops (same as was done previously).
3. Use the positions where the encoder indices were last seen for
zeroing the joints (this should correspond to the position where the
index is first seen when moving away from the end stop).

## Bug fixes

- `running_velocities` has only 100 elements, so don't use 1000 for
wrapping the index.
- Use absolute values of velocities for deciding if the joints stopped
(since they are moving in negative direction, velocities are also
negative and thus the velocity-check did not work correctly).

## Refactoring

- Use constants with describing names instead of magic numbers.
- Split the part for homing and for moving to the start position into
separate functions (the `calibrate` function calls both of them and
thus still works as before). Relevant parameters are passed to these
functions instead of being hard-coded inside.
- Remove additional loops for keeping the joints at the end stops. As
homing is now based on encoder index, the exact position at the end
stop is not so relevant anymore.

# How I Tested

By running it on the robot multiple times from different start positions.