### PR TITLE
Fix typo in copyright header

### DIFF
--- a/include/blmc_robots/quadruped.hpp
+++ b/include/blmc_robots/quadruped.hpp
@@ -2,7 +2,7 @@
  * \file quadruped.hpp
  * \author Manuel Wuthrich
  * \date 2018
- * \copyright Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+ * \copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 
  */
 

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -4,8 +4,8 @@
  * \author Manuel Wuthrich
  * \date 2018
  * \copyright Copyright (c) 2019, New York University and Max Planck
- Gesellshaft.
-
+ *            Gesellschaft.
+ *
  * This file declares the RealFinger class which defines the test
  * bench with 8 motors.
  */

--- a/include/blmc_robots/single_leg.hpp
+++ b/include/blmc_robots/single_leg.hpp
@@ -3,7 +3,7 @@
  * \brief The hardware wrapper of the RealFinger
  * \author Manuel Wuthrich
  * \date 2018
- * \copyright Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+ * \copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 
  */
 

--- a/include/blmc_robots/single_motor.hpp
+++ b/include/blmc_robots/single_motor.hpp
@@ -2,7 +2,7 @@
  * \file single_motor.hpp
  * \author Manuel Wuthrich
  * \date 2018
- * \copyright Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+ * \copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 
  */
 

--- a/include/blmc_robots/slider.hpp
+++ b/include/blmc_robots/slider.hpp
@@ -2,7 +2,7 @@
  * \file slider.hpp
  * \author Manuel Wuthrich
  * \date 2018
- * \copyright Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+ * \copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 
  */
 

--- a/include/blmc_robots/stuggihop.hpp
+++ b/include/blmc_robots/stuggihop.hpp
@@ -2,7 +2,7 @@
  * \file stuggihop.hpp
  * \author Manuel Wuthrich
  * \date 2018
- * \copyright Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+ * \copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 
  */
 

--- a/include/blmc_robots/teststand.hpp
+++ b/include/blmc_robots/teststand.hpp
@@ -2,7 +2,7 @@
  * \file teststand.hpp
  * \author Manuel Wuthrich
  * \date 2018
- * \copyright Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+ * \copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 
  */
 

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
# Description

Fix typo in the copyright headers: "Gesellshaft" --> "Gesellschaft".