### PR TITLE
Add non-blocking homing method to BlmcJointModule

### DIFF
--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -25,7 +25,7 @@ namespace blmc_robots
 /**
  * @brief Possible return values of the homing
  */
-enum HomingReturnCode {
+enum class HomingReturnCode {
     //! Homing was not initialized and can therefore not be performed.
     NOT_INITIALIZED = 0,
     //! Homing is currently running.

--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -20,6 +20,47 @@
 namespace blmc_robots
 {
 
+// TODO what is the best scope for those homing-related types?
+
+/**
+ * @brief Possible return values of the homing
+ */
+enum HomingReturnCode {
+    //! Homing was not initialized and can therefore not be performed.
+    NOT_INITIALIZED = 0,
+    //! Homing is currently running.
+    RUNNING,
+    //! Homing is succeeded.
+    SUCCEEDED,
+    //! Homing failed.
+    FAILED
+};
+
+
+/**
+ * @brief State variables required for the homing.
+ */
+struct HomingState {
+    //! Id of the joint.  Just use for debug prints.
+    int joint_id;
+    //! Max. distance to move while searching the encoder index.
+    double search_distance_limit_rad;
+    //! Offset from home position to zero position.
+    double home_offset_rad;
+    //! Step size for the position profile.
+    double profile_step_size_rad;
+    //! Timestamp from when the encoder index was seen the last time.
+    long int last_encoder_index_time_index;
+    //! Number of profile steps already taken.
+    uint32_t step_count;
+    //! Current target position of the position profile.
+    double target_position_rad;
+    //! Current status of the homing procedure.
+    HomingReturnCode status;
+};
+
+
+
 /**
  * @brief The BlmcJointModule class is containing the joint information. It is
  * here to help converting the data from the motor side to the joint side. It
@@ -116,6 +157,23 @@ public:
     double get_zero_angle() const;
 
     /**
+     * @brief Set control gains for PD position controller.
+     *
+     * @param kp P gain.
+     * @param kd D gain.
+     */
+    void set_position_control_gains(double kp, double kd);
+
+    /**
+     * @brief Execute one iteration of the position controller.
+     *
+     * @param target_position_rad  Target position.
+     *
+     * @return Torque command.
+     */
+    double execute_position_controller(double target_position_rad) const;
+
+    /**
      * @brief This method calibrate the joint position knowing the angle between
      * the closest (in positive torque) motor index and the theoretical zero
      * pose. Warning, this method should be called in a real time thread!
@@ -132,6 +190,47 @@ public:
     bool calibrate(double& angle_zero_to_index,
                    double& index_angle,
                    bool mechanical_calibration = false);
+
+
+    /**
+     * @brief Initialize the homing procedure.
+     *
+     * This has to be called before update_homing().
+     *
+     * @param joint_id ID of the joint.  This is only used for debug prints.
+     * @param search_distance_limit_rad  Maximum distance the motor moves while
+     *     searching for the encoder index.  Unit: radian.
+     * @param home_offset_rad  Offset from home position to zero position.
+     *     Unit: radian.
+     * @param profile_step_size_rad  Distance by which the target position of the
+     *     position profile is changed in each step.  Set to a negative value to
+     *     search for the next encoder index in negative direction.  Unit:
+     *     radian.
+     */
+    void init_homing(int joint_id, double search_distance_limit_rad, double
+            home_offset_rad, double profile_step_size_rad=0.001);
+
+    /**
+     * @brief Perform one step of homing on encoder index.
+     *
+     * Searches for the next encoder index in positive direction and, when
+     * found, sets it as home position.
+     *
+     * Only performs one step, so this method needs to be called in a loop.
+     *
+     * The motor is moved with a position profile until either the encoder index
+     * is reached or the search distance limit is exceeded.  The position is
+     * controlled with a simple PD controller.
+     *
+     * If the encoder index is found, its position is used as home position.
+     * The zero position is offset from the home position by adding the "home
+     * offset" to it (i.e. zero = home pos. + home offset).
+     * If the search distance limit is reached before the encoder index occurs,
+     * the homing fails.
+     *
+     * @return Status of the homing procedure.
+     */
+    HomingReturnCode update_homing();
 
 private:
     /**
@@ -198,6 +297,13 @@ private:
      * The program shut down if this value is achieved.
      */
     double max_current_;
+
+    //! @brief P gain of the position PD controller.
+    double position_control_gain_p_;
+    //! @brief D gain of the position PD controller.
+    double position_control_gain_d_;
+
+    struct HomingState homing_state_;
 };
 
 /**
@@ -400,6 +506,93 @@ public:
         }
         return index_angles;
     }
+
+    /**
+     * @brief Set position control gains for the specified joint.
+     *
+     * @param joint_id  ID of the joint (in range `[0, COUNT)`).
+     * @param kp P gain.
+     * @param kd D gain.
+     */
+    void set_position_control_gains(size_t joint_id, double kp, double kd)
+    {
+        modules_[joint_id]->set_position_control_gains(kp, kd);
+    }
+
+    /**
+     * @brief Set same position control gains for all joints.
+     *
+     * @param kp P gain.
+     * @param kd D gain.
+     */
+    void set_position_control_gains(double kp, double kd)
+    {
+        for(size_t i = 0; i < COUNT; i++)
+        {
+           set_position_control_gains(i, kp, kd);
+        }
+    }
+
+    /**
+     * @brief Perform homing for all joints.
+     *
+     * If one of the joints fails, the complete homing fails.  Otherwise it
+     * loops until all joints finished.
+     * If a joint is finished while others are still running, it is held at the
+     * home position.
+     *
+     * See BlmcJointModule::update_homing for details on the homing procedure.
+     *
+     * See BlmcJointModule::init_homing for description of the arguments.
+     *
+     * @return Final status of the homing procedure (either SUCCESS if all
+     *     joints succeeded or the return code of the first joint that failed).
+     */
+    HomingReturnCode execute_homing(double search_distance_limit_rad,
+            Vector home_offset_rad,
+            double profile_step_size_rad=0.001)
+    {
+        // Initialise homing for all joints
+        for(size_t i = 0; i < COUNT; i++)
+        {
+            modules_[i]->init_homing((int) i, search_distance_limit_rad,
+                    home_offset_rad[i], profile_step_size_rad);
+        }
+
+        // run homing for all joints until all of them are done
+        real_time_tools::Spinner spinner;
+        spinner.set_period(0.001);  // TODO magic number
+        HomingReturnCode homing_status;
+        do {
+            bool all_succeeded = true;
+            homing_status = HomingReturnCode::RUNNING;
+
+            for(size_t i = 0; i < COUNT; i++)
+            {
+                HomingReturnCode joint_result = modules_[i]->update_homing();
+
+                all_succeeded &= (joint_result == HomingReturnCode::SUCCEEDED);
+
+                if (joint_result == HomingReturnCode::NOT_INITIALIZED ||
+                        joint_result == HomingReturnCode::FAILED) {
+                    homing_status = joint_result;
+                    // abort homing
+                    break;
+                }
+            }
+
+            if (all_succeeded) {
+                homing_status = HomingReturnCode::SUCCEEDED;
+            }
+
+            spinner.spin();
+        } while (homing_status == HomingReturnCode::RUNNING);
+
+        return homing_status;
+    }
+
+
+
 
 private:
     /**


### PR DESCRIPTION
# Summary
Move the logic for homing based on encoder index to `BlmcJointModule`.

# Detailed

Add a non-blocking method `update_homing` to `BlmcJointModule` that only
performs one iteration of the homing.  This way it can be called in a
loop for each joint to run the homing of each joint simultaneously.
This method uses a simple position profile to move until the next
encoder index is found.  This index is then used as home position.

Add a `HomingState` struct to keep the state of homing between the calls
of `update_homing` and a method `init_homing` to initialize it.

Add a method `execute_homing` to `BlmcJointModules` that runs the homing
of all joints until finished.

Add methods `set_position_control_gains` and
`execute_position_controller` to `BlmcJointModule` to avoid redundant
controller implementations in different functions and to make it
possible to use different gains for different joints.

Use the new methods for homing in the `RealFinger` class.

# How I Tested
By running it on the Finger robot.