### PR TITLE
Add generic NJointBlmcRobotDriver and remove calibrate from constructor

### DIFF
--- a/demos/demo_finger_position_control.cpp
+++ b/demos/demo_finger_position_control.cpp
@@ -19,7 +19,7 @@
 using namespace blmc_robots;
 using namespace robot_interfaces;
 
-typedef std::tuple<std::shared_ptr<finger::Frontend>,
+typedef std::tuple<std::shared_ptr<FingerTypes::Frontend>,
                    std::shared_ptr<Sliders<3>>>
     FingerAndSliders;
 
@@ -37,10 +37,10 @@ static THREAD_FUNCTION_RETURN_TYPE control_loop(
     double kp = 0.2;
     double kd = 0.0025;
 
-    finger::Action desired_torque = finger::Action::Zero();
+    FingerTypes::Action desired_torque = FingerTypes::Action::Zero();
     while (true)
     {
-        finger::TimeIndex t = finger->append_desired_action(desired_torque);
+        TimeIndex t = finger->append_desired_action(desired_torque);
         desired_torque =
             kp * (sliders->get_positions() - finger->get_observation(t).angle) -
             kd * finger->get_observation(t).velocity;

--- a/demos/demo_finger_print_position.py
+++ b/demos/demo_finger_print_position.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import time
+"""Send zero-torque commands to Finger robot and print joint positions."""
 import numpy as np
 
 import py_finger
@@ -14,19 +14,13 @@ finger = py_finger.Frontend(finger_data)
 
 finger_backend.calibrate()
 
-# FIXME this makes the application hang
+# TODO this makes the application hang
 #t = finger.get_current_time_index()
 #print("t = %d" % t)
 
-kp = 5
-kd = 0
 desired_torque = np.zeros(3)
 
 while True:
-
-    desired_position = np.random.rand(3) * 6 - 1
-    for _ in range(300):
-        t = finger.append_desired_action(desired_torque)
-        #trq = finger.get_observation(t).torque
-        trq = finger.get_observation(t).angle
-        print("\r%6.3f %6.3f %6.3f" % (trq[0], trq[1], trq[2]), end="")
+    t = finger.append_desired_action(desired_torque)
+    pos = finger.get_observation(t).angle
+    print("\r%6.3f %6.3f %6.3f" % (pos[0], pos[1], pos[2]), end="")

--- a/demos/demo_finger_print_position.py
+++ b/demos/demo_finger_print_position.py
@@ -12,7 +12,7 @@ finger_backend = py_real_finger.create_real_finger_backend("can0", "can1",
 finger = py_finger.Frontend(finger_data)
 
 
-finger_backend.calibrate()
+finger_backend.initialize()
 
 # TODO this makes the application hang
 #t = finger.get_current_time_index()

--- a/demos/demo_finger_torque_control.cpp
+++ b/demos/demo_finger_torque_control.cpp
@@ -20,14 +20,14 @@ using namespace blmc_robots;
 using namespace robot_interfaces;
 
 
-typedef std::tuple<std::shared_ptr<finger::Frontend>,
+typedef std::tuple<std::shared_ptr<FingerTypes::Frontend>,
                    std::shared_ptr<Sliders<3>>>
     FingerAndSliders;
 
 struct Hardware
 {
     std::array<std::shared_ptr<blmc_drivers::CanBusMotorBoard>, 2> motor_boards;
-    std::shared_ptr<finger::Frontend> finger;
+    std::shared_ptr<FingerTypes::Frontend> finger;
     std::shared_ptr<Sliders<3>> sliders;
 };
 
@@ -39,7 +39,7 @@ static THREAD_FUNCTION_RETURN_TYPE control_loop(void *hardware_ptr)
     // position controller -----------------------------------------------------
     while (true)
     {
-        finger::TimeIndex t = hardware.finger->append_desired_action(
+        TimeIndex t = hardware.finger->append_desired_action(
             hardware.sliders->get_positions());
 
         hardware.finger->get_observation(t);

--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -14,6 +14,7 @@ def main():
                                                                finger_data)
     finger = py_finger.Frontend(finger_data)
 
+    finger_backend.calibrate()
 
     kp = 5
     kd = 0

--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -14,7 +14,7 @@ def main():
                                                                finger_data)
     finger = py_finger.Frontend(finger_data)
 
-    finger_backend.calibrate()
+    finger_backend.initialize()
 
     kp = 5
     kd = 0

--- a/demos/real_finger_print_pos.py
+++ b/demos/real_finger_print_pos.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import time
+import numpy as np
+
+import py_finger
+import py_real_finger
+
+
+finger_data = py_finger.Data()
+finger_backend = py_real_finger.create_real_finger_backend("can0", "can1",
+                                                           finger_data)
+finger = py_finger.Frontend(finger_data)
+
+
+finger_backend.calibrate()
+
+# FIXME this makes the application hang
+#t = finger.get_current_time_index()
+#print("t = %d" % t)
+
+kp = 5
+kd = 0
+desired_torque = np.zeros(3)
+
+while True:
+
+    desired_position = np.random.rand(3) * 6 - 1
+    for _ in range(300):
+        t = finger.append_desired_action(desired_torque)
+        #trq = finger.get_observation(t).torque
+        trq = finger.get_observation(t).angle
+        print("\r%6.3f %6.3f %6.3f" % (trq[0], trq[1], trq[2]), end="")

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -15,38 +15,105 @@
 #include <tuple>
 
 #include <blmc_robots/blmc_joint_module.hpp>
-#include "real_time_tools/spinner.hpp"
-#include "real_time_tools/timer.hpp"
+#include <real_time_tools/spinner.hpp>
+#include <real_time_tools/timer.hpp>
 
 #include <robot_interfaces/finger.hpp>
 
 namespace blmc_robots
 {
-class RealFingerDriver : public robot_interfaces::RobotDriver<
-                              robot_interfaces::finger::Action,
-                              robot_interfaces::finger::Observation>
+/**
+ * @brief Parameters related to the motor.
+ */
+struct MotorParameters
+{
+    //! @brief Maximum current that can be sent to the motor [A].
+    double max_current_A;
+
+    //! @brief Torque constant K_t of the motor [Nm/A].
+    double torque_constant_NmpA;
+
+    /**
+     * @brief Gear ratio between motor and joint.
+     *
+     * For a `n:1` ratio (i.e. one joint revolution requires n motor
+     * revolutions) set this value to `n`.
+     */
+    double gear_ratio;
+};
+
+/**
+ * @brief Parameters for the joint calibration (homing and go to initial pose).
+ */
+struct CalibrationParameters
+{
+    //! @brief Ratio of the max. torque that is used to find the end stop.
+    double torque_ratio;  // TODO better used fixed torque
+    //! @brief P-gain for the position controller.
+    double control_gain_kp;
+    //! @brief D-gain for the position controller.
+    double control_gain_kd;
+    //! @brief Tolerance for reaching the starting position.
+    double position_tolerance_rad;
+    //! @brief Timeout for reaching the starting position.
+    double move_timeout;
+};
+
+
+// TODO add "BLMC" in the name?
+/**
+ * @brief Base class for simple n-joint BLMC robots.
+ *
+ * This is a generic base class to easily implement drivers for simple BLMC
+ * robots that consist of a chain of joints.
+ *
+ * @tparam N_JOINTS Number of joints.
+ * @tparam N_MOTOR_BOARDS Number of motor control boards that are used.
+ */
+template <size_t N_JOINTS, size_t N_MOTOR_BOARDS>
+class NJointBlmcRobotDriver
+    : public robot_interfaces::RobotDriver<
+          typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Action,
+          typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Observation>
 {
 public:
-    typedef robot_interfaces::finger::Action Action;
-    typedef robot_interfaces::finger::Observation Observation;
-    typedef robot_interfaces::finger::Vector Vector;
-    typedef std::array<std::shared_ptr<blmc_drivers::MotorInterface>, 3> Motors;
-    typedef std::array<std::shared_ptr<blmc_drivers::CanBusMotorBoard>, 2>
+    typedef
+        typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Action Action;
+    typedef typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Observation
+        Observation;
+    typedef
+        typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Vector Vector;
+    typedef std::array<std::shared_ptr<blmc_drivers::MotorInterface>, N_JOINTS>
+        Motors;
+    typedef std::array<std::shared_ptr<blmc_drivers::CanBusMotorBoard>,
+                       N_MOTOR_BOARDS>
         MotorBoards;
 
-    RealFingerDriver(const std::string &can_0, const std::string &can_1)
-        : RealFingerDriver(create_motor_boards(can_0, can_1))
+    NJointBlmcRobotDriver(const std::array<std::string, N_MOTOR_BOARDS> &can_ports,
+                      const MotorParameters &motor_parameters,
+                      const double max_action_duration_s,
+                      const double max_inter_action_duration_s)
+        : NJointBlmcRobotDriver(create_motor_boards(can_ports),
+                            motor_parameters,
+                            max_action_duration_s,
+                            max_inter_action_duration_s)
     {
     }
 
-    RealFingerDriver(const MotorBoards &motor_boards)
-        : RealFingerDriver(create_motors(motor_boards))
+    NJointBlmcRobotDriver(const MotorBoards &motor_boards,
+                      const MotorParameters &motor_parameters,
+                      const double max_action_duration_s,
+                      const double max_inter_action_duration_s)
+        : NJointBlmcRobotDriver(create_motors(motor_boards),
+                            motor_parameters,
+                            max_action_duration_s,
+                            max_inter_action_duration_s)
     {
         motor_boards_ = motor_boards;
 
-        max_torque_ = 2.0 * 0.02 * 9.0;
-
-        calibrate();
+        max_torque_Nm_ = motor_parameters.max_current_A *
+                         motor_parameters.torque_constant_NmpA *
+                         motor_parameters.gear_ratio;
 
         for (size_t i = 0; i < motor_boards_.size(); i++)
         {
@@ -54,23 +121,27 @@ public:
         }
     }
 
-    static MotorBoards create_motor_boards(const std::string &can_0,
-                                           const std::string &can_1)
+    static MotorBoards create_motor_boards(
+        const std::array<std::string, N_MOTOR_BOARDS> &can_ports)
     {
         // setup can buses -----------------------------------------------------
-        std::array<std::shared_ptr<blmc_drivers::CanBus>, 2> can_buses;
-        can_buses[0] = std::make_shared<blmc_drivers::CanBus>(can_0);
-        can_buses[1] = std::make_shared<blmc_drivers::CanBus>(can_1);
+        std::array<std::shared_ptr<blmc_drivers::CanBus>, N_MOTOR_BOARDS>
+            can_buses;
+        for (size_t i = 0; i < can_buses.size(); i++)
+        {
+            can_buses[i] = std::make_shared<blmc_drivers::CanBus>(can_ports[i]);
+        }
 
         // set up motor boards -------------------------------------------------
         MotorBoards motor_boards;
-        for (size_t i = 0; i < 2; i++)
+        for (size_t i = 0; i < motor_boards.size(); i++)
         {
             motor_boards[i] = std::make_shared<blmc_drivers::CanBusMotorBoard>(
-                can_buses[i], 1000,
-                10);  /// \TODO: reduce the timeout further!!
+                can_buses[i], 1000, 10);
+            /// \TODO: reduce the timeout further!!
         }
-        for (size_t i = 0; i < 2; i++)
+
+        for (size_t i = 0; i < motor_boards.size(); i++)
         {
             motor_boards[i]->wait_until_ready();
         }
@@ -81,34 +152,6 @@ public:
     Vector get_measured_index_angles() const
     {
         return joint_modules_.get_measured_index_angles();
-    }
-
-protected:
-    RealFingerDriver(const Motors &motors)
-        : RobotDriver(0.003, 0.005),
-          joint_modules_(motors, 0.02 * Vector::Ones(), 9.0 * Vector::Ones(),
-                         Vector::Zero())
-    {
-    }
-
-protected:
-    Action apply_action(const Action &desired_action) override
-    {
-        double start_time_sec = real_time_tools::Timer::get_current_time_sec();
-
-        Observation observation = get_latest_observation();
-        Vector kd(0.08, 0.08, 0.04);
-        double max_torque = 0.36;
-        Action applied_action =
-            mct::clamp(desired_action, -max_torque, max_torque);
-        applied_action = applied_action - kd.cwiseProduct(observation.velocity);
-        applied_action = mct::clamp(applied_action, -max_torque, max_torque);
-
-        joint_modules_.set_torques(applied_action);
-        joint_modules_.send_torques();
-        real_time_tools::Timer::sleep_until_sec(start_time_sec + 0.001);
-
-        return applied_action;
     }
 
 public:
@@ -122,17 +165,6 @@ public:
     }
 
 protected:
-    void shutdown() override
-    {
-        for (size_t i = 0; i < motor_boards_.size(); i++)
-        {
-            motor_boards_[i]->pause_motors();
-        }
-    }
-
-protected:
-    Eigen::Vector3d max_angles_;
-
     static Motors create_motors(const MotorBoards &motor_boards)
     {
         // set up motors -------------------------------------------------------
@@ -143,6 +175,48 @@ protected:
 
         return motors;
     }
+
+    NJointBlmcRobotDriver(const Motors &motors,
+                      const MotorParameters &motor_parameters,
+                      const double max_action_duration_s,
+                      const double max_inter_action_duration_s)
+        : robot_interfaces::RobotDriver<Action, Observation>(
+              max_action_duration_s, max_inter_action_duration_s),
+          joint_modules_(motors,
+                         motor_parameters.torque_constant_NmpA * Vector::Ones(),
+                         motor_parameters.gear_ratio * Vector::Ones(),
+                         Vector::Zero())
+    {
+    }
+
+    Action apply_action(const Action &desired_action) override
+    {
+        double start_time_sec = real_time_tools::Timer::get_current_time_sec();
+
+        Observation observation = get_latest_observation();
+        Action applied_action =
+            mct::clamp(desired_action, -max_torque_Nm_, max_torque_Nm_);
+        applied_action =
+            applied_action - safety_kd_.cwiseProduct(observation.velocity);
+        applied_action =
+            mct::clamp(applied_action, -max_torque_Nm_, max_torque_Nm_);
+
+        joint_modules_.set_torques(applied_action);
+        joint_modules_.send_torques();
+        real_time_tools::Timer::sleep_until_sec(start_time_sec + 0.001);
+
+        return applied_action;
+    }
+
+    void shutdown() override
+    {
+        for (size_t i = 0; i < motor_boards_.size(); i++)
+        {
+            motor_boards_[i]->pause_motors();
+        }
+    }
+
+    virtual CalibrationParameters get_calibration_parameters() = 0;
 
     /// \todo: calibrate needs to be cleaned and should probably not be here
     /// there are two identical copies in disentanglement_platform and finger,
@@ -172,12 +246,14 @@ protected:
      *
      * @param torque_ratio Ratio of max. torque that is used to move the joints.
      * @param home_offset_rad Offset between the home position and the desired
-     * zero
-     *                    position.
+     *     zero position.
      */
     bool home_on_index_after_negative_end_stop(
         double torque_ratio, Vector home_offset_rad = Vector::Zero())
     {
+        // TODO this can be dangerous in generic NJointBlmcRobotDriver as not all
+        // robots have end stops!
+
         /// \todo: this relies on the safety check in the motor right now,
         /// which is maybe not the greatest idea. Without the velocity and
         /// torque limitation in the motor this would be very unsafe
@@ -246,8 +322,10 @@ protected:
      *     procedure is aborted. Unit: Number of control loop cycles.
      * @return True if goal position is reached, false if timeout is exceeded.
      */
-    bool move_to_position(const Vector &goal_pos, const double kp,
-                          const double kd, const double tolerance,
+    bool move_to_position(const Vector &goal_pos,
+                          const double kp,
+                          const double kd,
+                          const double tolerance,
                           const uint32_t timeout_cycles)
     {
         /// \todo: this relies on the safety check in the motor right now,
@@ -272,18 +350,6 @@ protected:
             // we implement here a small PD control at the current level
             desired_torque = kp * position_error - kd * velocity;
 
-#ifdef VERBOSE
-            if (cycle_count % 100 == 0)
-            {
-                rt_printf(
-                    "--\n"
-                    "position error: %10.5f, %10.5f, %10.5f\n"
-                    "velocity:       %10.5f, %10.5f, %10.5f\n",
-                    position_error[0], position_error[1], position_error[2],
-                    velocity[0], velocity[1], velocity[2]);
-            }
-#endif
-
             // Check if the goal is reached (position error below tolerance and
             // velocity close to zero).
             constexpr double ZERO_VELOCITY = 1e-4;
@@ -297,46 +363,30 @@ protected:
     }
 
     /**
-     * @brief this is an initial calibration procedure executed before the
-     * actual control loop to have angle readings in an absolute coordinate
-     * frame.
+     * @brief Find home position of all joints and move to start position.
      *
-     * The finger reaches its joint limits by applying a constant negative
-     * torque simultaneously in all the joints. Be aware that this procedure
-     * assumes safe motors where the maximum velocities are constrained.
+     * Homes all joints using home_on_index_after_negative_end_stop.  When
+     * finished, move the joint to the starting position (defined in
+     * `starting_position_rad_`).
      *
-     * The calibration procedure is finished once the joint velocities are zero
-     * according to a moving average estimation of them.
      */
     void calibrate()
     {
-        constexpr double TORQUE_RATIO = 0.6;
-        constexpr double CONTROL_GAIN_KP = 0.4;
-        constexpr double CONTROL_GAIN_KD = 0.0025;
-        constexpr double POSITION_TOLERANCE_RAD = 0.2;
-        constexpr double MOVE_TIMEOUT = 2000;
+        const CalibrationParameters params = get_calibration_parameters();
 
-        // Offset between home position and zero.  Defined such that the zero
-        // position is at the negative end stop (for compatibility with old
-        // homing method).
-        Vector home_offset_rad;
-        home_offset_rad << -0.54, -0.17, 0.0;
+        joint_modules_.set_position_control_gains(params.control_gain_kp,
+                                                  params.control_gain_kd);
 
-        // Start position to which the robot moves after homing.
-        Vector starting_position_rad;
-        starting_position_rad << 1.5, 1.5, 3.0;
-
-        joint_modules_.set_position_control_gains(CONTROL_GAIN_KP,
-                                                  CONTROL_GAIN_KD);
-
-        bool is_homed = home_on_index_after_negative_end_stop(TORQUE_RATIO,
-                                                              home_offset_rad);
+        bool is_homed = home_on_index_after_negative_end_stop(
+            params.torque_ratio, home_offset_rad_);
 
         if (is_homed)
         {
-            bool reached_goal = move_to_position(
-                starting_position_rad, CONTROL_GAIN_KP, CONTROL_GAIN_KD,
-                POSITION_TOLERANCE_RAD, MOVE_TIMEOUT);
+            bool reached_goal = move_to_position(starting_position_rad_,
+                                                 params.control_gain_kp,
+                                                 params.control_gain_kd,
+                                                 params.position_tolerance_rad,
+                                                 params.move_timeout);
             if (!reached_goal)
             {
                 rt_printf("Failed to reach goal, timeout exceeded.\n");
@@ -344,30 +394,87 @@ protected:
         }
     }
 
-private:
-    /// todo: this should probably go away
-    double max_torque_;
+protected:
+    /**
+     * \brief Offset between home position and zero.
+     *
+     * Defined such that the zero position is at the negative end stop (for
+     * compatibility with old homing method).
+     */
+    Vector home_offset_rad_ = Vector::Zero();
 
-    BlmcJointModules<3> joint_modules_;
+    //! \brief Start position to which the robot moves after homing.
+    Vector starting_position_rad_ = Vector::Zero();
+
+    //! \brief D-gain to dampen velocity.  Set to zero to disable damping.
+    Vector safety_kd_ = Vector::Zero();
+
+    /// todo: this should probably go away
+    double max_torque_Nm_;
+
+    BlmcJointModules<N_JOINTS> joint_modules_;
     MotorBoards motor_boards_;
 
-    /// todo: this should probably go away
-
 public:
-    Vector get_max_torques() const { return max_torque_ * Vector::Ones(); }
+    Vector get_max_torques() const { return max_torque_Nm_ * Vector::Ones(); }
 };
 
-robot_interfaces::finger::BackendPtr create_real_finger_backend(
-    const std::string &can_0, const std::string &can_1,
-    robot_interfaces::finger::DataPtr robot_data)
+class RealFingerDriver : public NJointBlmcRobotDriver<3, 2>
 {
-    std::shared_ptr<
-        robot_interfaces::RobotDriver<robot_interfaces::finger::Action,
-                                      robot_interfaces::finger::Observation>>
+public:
+    RealFingerDriver(const std::string &can_0, const std::string &can_1)
+        : NJointBlmcRobotDriver<3, 2>({can_0, can_1},
+                                  {.max_current_A = 2.0,
+                                   .torque_constant_NmpA = 0.02,
+                                   .gear_ratio = 9.0},
+                                  0.003,
+                                  0.005)
+    {
+        initialize();
+    }
+
+    // TODO do we need this constructor?
+    // RealFingerDriver(const MotorBoards &motor_boards)
+    //    : NJointBlmcRobotDriver<3, 2>(motor_boards, 0.003, 0.005)
+    //{
+    //    initialize();
+    //}
+
+protected:
+    // this is needed to be able to overload the method above.
+    using NJointBlmcRobotDriver<3, 2>::calibrate;
+
+    void initialize()
+    {
+        safety_kd_ << 0.08, 0.08, 0.04;
+        home_offset_rad_ << -0.54, -0.17, 0.0;
+        starting_position_rad_ << 1.5, 1.5, 3.0;
+    }
+
+    CalibrationParameters get_calibration_parameters()
+    {
+        return {
+            .torque_ratio = 0.6,
+            .control_gain_kp = 0.4,
+            .control_gain_kd = 0.0025,
+            .position_tolerance_rad = 0.2,
+            .move_timeout = 2000,
+        };
+    }
+};
+
+robot_interfaces::FingerTypes::BackendPtr create_real_finger_backend(
+    const std::string &can_0,
+    const std::string &can_1,
+    robot_interfaces::FingerTypes::DataPtr robot_data)
+{
+    std::shared_ptr<robot_interfaces::RobotDriver<
+        robot_interfaces::FingerTypes::Action,
+        robot_interfaces::FingerTypes::Observation>>
         robot = std::make_shared<RealFingerDriver>(can_0, can_1);
 
-    auto backend =
-        std::make_shared<robot_interfaces::finger::Backend>(robot, robot_data);
+    auto backend = std::make_shared<robot_interfaces::FingerTypes::Backend>(
+        robot, robot_data);
     backend->set_max_action_repetitions(-1);
 
     return backend;

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -164,17 +164,17 @@ public:
 protected:
     Action apply_action(const Action &desired_action) override
     {
-        if (!is_calibrated_)
+        if (!is_initialized_)
         {
             throw std::runtime_error(
-                "Robot needs to be calibrated before applying actions.  Run "
-                "the `calibrate()` method.");
+                "Robot needs to be initialized before applying actions.  Run "
+                "the `initialize()` method.");
         }
 
-        return apply_action_uncalibrated(desired_action);
+        return apply_action_uninitialized(desired_action);
     }
 
-    Action apply_action_uncalibrated(const Action &desired_action)
+    Action apply_action_uninitialized(const Action &desired_action)
     {
         double start_time_sec = real_time_tools::Timer::get_current_time_sec();
 
@@ -255,7 +255,7 @@ protected:
                 STOP_VELOCITY))
         {
             Vector torques = -1 * torque_ratio * get_max_torques();
-            apply_action_uncalibrated(torques);
+            apply_action_uninitialized(torques);
             Vector abs_velocities =
                 get_latest_observation().velocity.cwiseAbs();
 
@@ -335,16 +335,16 @@ protected:
      * `initial_position_rad_`).
      *
      */
-    void calibrate() override
+    void initialize() override
     {
         joint_modules_.set_position_control_gains(
             calibration_parameters_.control_gain_kp,
             calibration_parameters_.control_gain_kd);
 
-        is_calibrated_ = home_on_index_after_negative_end_stop(
+        is_initialized_ = home_on_index_after_negative_end_stop(
             calibration_parameters_.torque_ratio, home_offset_rad_);
 
-        if (is_calibrated_)
+        if (is_initialized_)
         {
             bool reached_goal = move_to_position(
                 initial_position_rad_,
@@ -384,7 +384,7 @@ protected:
 
     CalibrationParameters calibration_parameters_;
 
-    bool is_calibrated_ = false;
+    bool is_initialized_ = false;
 
 public:
     Vector get_max_torques() const

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -114,10 +114,7 @@ public:
                          motor_parameters.torque_constant_NmpA *
                          motor_parameters.gear_ratio;
 
-        for (size_t i = 0; i < motor_boards_.size(); i++)
-        {
-            motor_boards_[i]->pause_motors();
-        }
+        pause_motors();
     }
 
     static MotorBoards create_motor_boards(
@@ -146,6 +143,14 @@ public:
         }
 
         return motor_boards;
+    }
+
+    void pause_motors()
+    {
+        for (size_t i = 0; i < motor_boards_.size(); i++)
+        {
+            motor_boards_[i]->pause_motors();
+        }
     }
 
     Vector get_measured_index_angles() const
@@ -216,10 +221,7 @@ protected:
 
     void shutdown() override
     {
-        for (size_t i = 0; i < motor_boards_.size(); i++)
-        {
-            motor_boards_[i]->pause_motors();
-        }
+        pause_motors();
     }
 
     virtual CalibrationParameters get_calibration_parameters() = 0;
@@ -406,6 +408,8 @@ protected:
             // calibration failed
             is_calibrated_ = false;
         }
+
+        pause_motors();
     }
 
 protected:
@@ -432,7 +436,10 @@ protected:
     bool is_calibrated_ = false;
 
 public:
-    Vector get_max_torques() const { return max_torque_Nm_ * Vector::Ones(); }
+    Vector get_max_torques() const
+    {
+        return max_torque_Nm_ * Vector::Ones();
+    }
 };
 
 class RealFingerDriver : public NJointBlmcRobotDriver<3, 2>

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -59,8 +59,6 @@ struct CalibrationParameters
     double move_timeout;
 };
 
-
-// TODO add "BLMC" in the name?
 /**
  * @brief Base class for simple n-joint BLMC robots.
  *
@@ -89,25 +87,26 @@ public:
                        N_MOTOR_BOARDS>
         MotorBoards;
 
-    NJointBlmcRobotDriver(const std::array<std::string, N_MOTOR_BOARDS> &can_ports,
-                      const MotorParameters &motor_parameters,
-                      const double max_action_duration_s,
-                      const double max_inter_action_duration_s)
+    NJointBlmcRobotDriver(
+        const std::array<std::string, N_MOTOR_BOARDS> &can_ports,
+        const MotorParameters &motor_parameters,
+        const double max_action_duration_s,
+        const double max_inter_action_duration_s)
         : NJointBlmcRobotDriver(create_motor_boards(can_ports),
-                            motor_parameters,
-                            max_action_duration_s,
-                            max_inter_action_duration_s)
+                                motor_parameters,
+                                max_action_duration_s,
+                                max_inter_action_duration_s)
     {
     }
 
     NJointBlmcRobotDriver(const MotorBoards &motor_boards,
-                      const MotorParameters &motor_parameters,
-                      const double max_action_duration_s,
-                      const double max_inter_action_duration_s)
+                          const MotorParameters &motor_parameters,
+                          const double max_action_duration_s,
+                          const double max_inter_action_duration_s)
         : NJointBlmcRobotDriver(create_motors(motor_boards),
-                            motor_parameters,
-                            max_action_duration_s,
-                            max_inter_action_duration_s)
+                                motor_parameters,
+                                max_action_duration_s,
+                                max_inter_action_duration_s)
     {
         motor_boards_ = motor_boards;
 
@@ -177,9 +176,9 @@ protected:
     }
 
     NJointBlmcRobotDriver(const Motors &motors,
-                      const MotorParameters &motor_parameters,
-                      const double max_action_duration_s,
-                      const double max_inter_action_duration_s)
+                          const MotorParameters &motor_parameters,
+                          const double max_action_duration_s,
+                          const double max_inter_action_duration_s)
         : robot_interfaces::RobotDriver<Action, Observation>(
               max_action_duration_s, max_inter_action_duration_s),
           joint_modules_(motors,
@@ -193,7 +192,9 @@ protected:
     {
         if (!is_calibrated_)
         {
-            throw std::runtime_error("Robot needs to be calibrated before applying actions.  Run the `calibrate()` method.");
+            throw std::runtime_error(
+                "Robot needs to be calibrated before applying actions.  Run "
+                "the `calibrate()` method.");
         }
 
         double start_time_sec = real_time_tools::Timer::get_current_time_sec();
@@ -252,8 +253,8 @@ protected:
     bool home_on_index_after_negative_end_stop(
         double torque_ratio, Vector home_offset_rad = Vector::Zero())
     {
-        // TODO this can be dangerous in generic NJointBlmcRobotDriver as not all
-        // robots have end stops!
+        // TODO this can be dangerous in generic NJointBlmcRobotDriver as not
+        // all robots have end stops!
 
         /// \todo: this relies on the safety check in the motor right now,
         /// which is maybe not the greatest idea. Without the velocity and
@@ -405,7 +406,6 @@ protected:
             // calibration failed
             is_calibrated_ = false;
         }
-
     }
 
 protected:
@@ -440,11 +440,11 @@ class RealFingerDriver : public NJointBlmcRobotDriver<3, 2>
 public:
     RealFingerDriver(const std::string &can_0, const std::string &can_1)
         : NJointBlmcRobotDriver<3, 2>({can_0, can_1},
-                                  {.max_current_A = 2.0,
-                                   .torque_constant_NmpA = 0.02,
-                                   .gear_ratio = 9.0},
-                                  0.003,
-                                  0.005)
+                                      {.max_current_A = 2.0,
+                                       .torque_constant_NmpA = 0.02,
+                                       .gear_ratio = 9.0},
+                                      0.003,
+                                      0.005)
     {
         initialize();
     }
@@ -457,7 +457,6 @@ public:
     //}
 
 protected:
-
     void initialize()
     {
         safety_kd_ << 0.08, 0.08, 0.04;

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -469,9 +469,9 @@ protected:
     {
         return {
             .torque_ratio = 0.6,
-            .control_gain_kp = 0.4,
-            .control_gain_kd = 0.0025,
-            .position_tolerance_rad = 0.2,
+            .control_gain_kp = 3.0,
+            .control_gain_kd = 0.03,
+            .position_tolerance_rad = 0.05,
             .move_timeout = 2000,
         };
     }

--- a/include/blmc_robots/real_finger.hpp
+++ b/include/blmc_robots/real_finger.hpp
@@ -230,10 +230,6 @@ protected:
         // TODO this can be dangerous in generic NJointBlmcRobotDriver as not
         // all robots have end stops!
 
-        /// \todo: this relies on the safety check in the motor right now,
-        /// which is maybe not the greatest idea. Without the velocity and
-        /// torque limitation in the motor this would be very unsafe
-
         //! Min. number of steps when moving to the end stop.
         constexpr uint32_t MIN_STEPS_MOVE_TO_END_STOP = 1000;
         //! Size of the window when computing average velocity.
@@ -273,9 +269,6 @@ protected:
             step_count++;
         }
 
-        // need to "pause" as the desired actions queue is not filled while
-        // homing is running.
-
         // Home on encoder index
         HomingReturnCode homing_status = joint_modules_.execute_homing(
             SEARCH_DISTANCE_LIMIT_RAD, home_offset_rad);
@@ -304,10 +297,6 @@ protected:
                           const double tolerance,
                           const uint32_t timeout_cycles)
     {
-        /// \todo: this relies on the safety check in the motor right now,
-        /// which is maybe not the greatest idea. Without the velocity and
-        /// torque limitation in the motor this would be very unsafe
-
         bool reached_goal = false;
         int cycle_count = 0;
         Vector desired_torque = Vector::Zero();


### PR DESCRIPTION
# Description
- Convert the `RealFingerDriver` into a more generic `NJointBlmcRobotDriver`.  The actual `RealFingerDriver` now derives from this and only specifies the robot-specific numbers.
- Remove the call of the `calibrate()` method from the constructor and instead ensure (by throwing an exception) that it is explicitly called by the user before an action can be applied.
- Sharpen the controller for the calibration and reduce the tolerance.
- Add a simple demo script that sends zero-torque commands and continuously prints the joint angles.

# How I Tested
By running the demo scripts.

# Do not merge before
https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/2