### PR TITLE
auto-define-os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CATKIN_PKGS ${CATKIN_PKGS}
 )
 find_package(catkin REQUIRED COMPONENTS ${CATKIN_PKGS})
 
-define_os()
 search_for_eigen()
 
 ######################################################


### PR DESCRIPTION
# What changed?

I updated the CMake Macro search_for_cereal to search_for_cereal_required in order to make sure this dependency is not missing.

# Merge after the following merge:

machines-in-motion/mpi_cmake_modules#2