### PR TITLE
Configure if robot has end stop and consider during homing

### DIFF
--- a/include/blmc_robots/one_joint_driver.hpp
+++ b/include/blmc_robots/one_joint_driver.hpp
@@ -58,7 +58,8 @@ private:
                                           .position_tolerance_rad = 0.05,
                                           .move_timeout = 2000,
                                       },
-                                      make_vector(0.08))
+                                      make_vector(0.08),
+                                      true)
     {
         home_offset_rad_ << home_offset_rad;
         initial_position_rad_ << -home_offset_rad;

--- a/include/blmc_robots/real_finger_driver.hpp
+++ b/include/blmc_robots/real_finger_driver.hpp
@@ -44,7 +44,8 @@ private:
                                           .position_tolerance_rad = 0.05,
                                           .move_timeout = 2000,
                                       },
-                                      Vector(0.08, 0.08, 0.04))
+                                      Vector(0.08, 0.08, 0.04),
+                                      true)
     {
         home_offset_rad_ << -0.54, -0.17, 0.0;
         initial_position_rad_ << 1.5, 1.5, 3.0;


### PR DESCRIPTION
# Description
Add a `has_endstop_` flag to the `NJointBlmcRobotDriver` class that
needs to be set via the constructor.
Use it in the homing method to skip the "move against end stop" step in
case the robot does not have an end stop.

This is important as in the general case a robot may not have end stops and running the end stop search in this case could break the robot.

# How I Tested
Using a demo script for the real finger.