### PR TITLE
Integrate position controller into NJointBlmcRobotDriver

### DIFF
--- a/demos/demo_data_logging.py
+++ b/demos/demo_data_logging.py
@@ -4,28 +4,29 @@
 import time
 import numpy as np
 
-import robot_interfaces
+from robot_interfaces import finger
 import blmc_robots
 
 def main():
 
-    finger_data = robot_interfaces.finger.Data()
+    finger_data = finger.Data()
     finger_backend = blmc_robots.create_fake_finger_backend(finger_data)
-    finger = robot_interfaces.finger.Frontend(finger_data)
+    finger_frontend = finger.Frontend(finger_data)
 
     desired_torque = np.zeros(3)
 
     block_size = 100
     filename = "log.csv";
 
-    finger_logger = robot_interfaces.finger.FingerLogger(finger_data, block_size, filename)
+    finger_logger = finger.FingerLogger(finger_data, block_size, filename)
     finger_logger.run()
 
     while True:
         for _ in range(1000):
-            t = finger.append_desired_action(desired_torque)
+            t = finger_frontend.append_desired_action(
+                finger.Action(torque=desired_torque))
 
-            pos = finger.get_observation(t).angle
+            pos = finger_frontend.get_observation(t).angle
 
 if __name__ == "__main__":
     main()

--- a/demos/demo_fake_finger.py
+++ b/demos/demo_fake_finger.py
@@ -32,6 +32,8 @@ def main():
     kp = 5
     kd = 0
 
+    Action = robot_interfaces.finger.Action
+
     desired_torque = np.zeros(3)
     while True:
         # Run a position controller that randomly changes the desired position
@@ -43,7 +45,7 @@ def main():
             # Appends a torque command ("action") to the action queue.
             # Returns the time step at which the action is going to be
             # executed.
-            t = finger.append_desired_action(desired_torque)
+            t = finger.append_desired_action(Action(torque=desired_torque))
 
             # Get observations of the time step t.  Will block and wait if t is
             # in the future.

--- a/demos/demo_finger_position_control.cpp
+++ b/demos/demo_finger_position_control.cpp
@@ -37,19 +37,19 @@ static THREAD_FUNCTION_RETURN_TYPE control_loop(
     double kp = 0.2;
     double kd = 0.0025;
 
-    FingerTypes::Action desired_torque = FingerTypes::Action::Zero();
+    FingerTypes::Action desired_action = FingerTypes::Action::Zero();
     while (true)
     {
-        TimeIndex t = finger->append_desired_action(desired_torque);
-        desired_torque =
+        TimeIndex t = finger->append_desired_action(desired_action);
+        desired_action.torque =
             kp * (sliders->get_positions() - finger->get_observation(t).angle) -
             kd * finger->get_observation(t).velocity;
 
         // print ---------------------------------------------------------------
         if ((t % 1000) == 0)
         {
-            std::cout << "desired_torque: " << finger->get_desired_action(t)
-                      << std::endl;
+            std::cout << "desired_torque: "
+                      << finger->get_desired_action(t).torque << std::endl;
             std::cout << "angles: " << finger->get_observation(t).angle
                       << std::endl;
         }

--- a/demos/demo_finger_print_position.py
+++ b/demos/demo_finger_print_position.py
@@ -8,7 +8,7 @@ import blmc_robots
 
 finger_data = robot_interfaces.finger.Data()
 finger_backend = blmc_robots.create_real_finger_backend("can0", "can1",
-                                                           finger_data)
+                                                        finger_data)
 finger = robot_interfaces.finger.Frontend(finger_data)
 
 
@@ -18,9 +18,7 @@ finger_backend.initialize()
 #t = finger.get_current_time_index()
 #print("t = %d" % t)
 
-desired_torque = np.zeros(3)
-
 while True:
-    t = finger.append_desired_action(desired_torque)
+    t = finger.append_desired_action(robot_interfaces.finger.Action())
     pos = finger.get_observation(t).angle
     print("\r%6.3f %6.3f %6.3f" % (pos[0], pos[1], pos[2]), end="")

--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -9,6 +9,72 @@ import robot_interfaces
 import blmc_robots
 
 
+def get_random_position():
+    """Generate a random position within a save range."""
+    position_min = np.array([1, 0, 0])
+    position_max = np.array([3, 2, 5])
+
+    position_range = position_max - position_min
+
+    return position_min + np.random.rand(3) * position_range
+
+
+def demo_torque_commands(finger):
+    """Demo for running a custom controller and sending only torque commands.
+    """
+
+    # Control gains
+    kp = 5
+    kd = 0
+
+    desired_torque = np.zeros(3)
+    while True:
+        # Run a position controller that randomly changes the desired position
+        # every 300 steps.
+        # One time step corresponds to roughly 1 ms.
+
+        desired_position = get_random_position()
+        for _ in range(300):
+            # Appends a torque command ("action") to the action queue.
+            # Returns the time step at which the action is going to be
+            # executed.
+            action = robot_interfaces.finger.Action(torque=desired_torque)
+            t = finger.append_desired_action(action)
+
+            # Get observations of the time step t.  Will block and wait if t is
+            # in the future.
+            current_position = finger.get_observation(t).angle
+            current_velocity = finger.get_observation(t).velocity
+
+            # Simple PD controller to compute desired torque for next iteration
+            position_error = desired_position - current_position
+            desired_torque = kp * position_error - kd * current_velocity
+
+        # print current position from time to time
+        print("Position: %s" % current_position)
+
+
+def demo_position_commands(finger):
+    """Demo for directly sending position commands."""
+
+    while True:
+        # Run a position controller that randomly changes the desired position
+        # every 300 steps.
+        # One time step corresponds to roughly 1 ms.
+
+        desired_position = get_random_position()
+        for _ in range(300):
+            # Appends a torque command ("action") to the action queue.
+            # Returns the time step at which the action is going to be
+            # executed.
+            action = robot_interfaces.finger.Action(position=desired_position)
+            t = finger.append_desired_action(action)
+
+        # print current position from time to time
+        print("Position: %s" % finger.get_observation(t).angle)
+
+
+
 def main():
     # Storage for all observations, actions, etc.
     finger_data = robot_interfaces.finger.Data()
@@ -25,34 +91,9 @@ def main():
     # Initializes the robot (e.g. performs homing).
     real_finger_backend.initialize()
 
-    # Control gains
-    kp = 5
-    kd = 0
 
-    desired_torque = np.zeros(3)
-    while True:
-        # Run a position controller that randomly changes the desired position
-        # every 300 steps.
-        # One time step corresponds to roughly 1 ms.
-
-        desired_position = np.random.rand(3) * 6 - 1
-        for _ in range(300):
-            # Appends a torque command ("action") to the action queue.
-            # Returns the time step at which the action is going to be
-            # executed.
-            t = finger.append_desired_action(desired_torque)
-
-            # Get observations of the time step t.  Will block and wait if t is
-            # in the future.
-            current_position = finger.get_observation(t).angle
-            current_velocity = finger.get_observation(t).velocity
-
-            # Simple PD controller to compute desired torque for next iteration
-            position_error = desired_position - current_position
-            desired_torque = kp * position_error - kd * current_velocity
-
-        # print current position from time to time
-        print("Position: %s" % current_position)
+    #demo_torque_commands(finger)
+    demo_position_commands(finger)
 
 
 if __name__ == "__main__":

--- a/demos/demo_sparse_position_control.py
+++ b/demos/demo_sparse_position_control.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Basic demo on how to control position for only some joints.
+
+This demo shows how to run a position controller on only the upper two joints
+of the Finger robot while controlling zero-torque on the tip joint.
+"""
+import numpy as np
+
+import robot_interfaces
+import blmc_robots
+
+
+def main():
+    # Storage for all observations, actions, etc.
+    finger_data = robot_interfaces.finger.Data()
+
+    # The backend sends actions from the data to the robot and writes
+    # observations from the robot to the data.
+    real_finger_backend = blmc_robots.create_real_finger_backend("can0",
+                                                                 "can1",
+                                                                 finger_data)
+
+    # The frontend is used by the user to get observations and send actions
+    finger = robot_interfaces.finger.Frontend(finger_data)
+
+    # Initializes the robot (e.g. performs homing).
+    real_finger_backend.initialize()
+
+    while True:
+        # set the position for the last joint to NaN to disable the position
+        # controller for this joint
+        desired_position = [0.7, 1.5, np.nan]
+
+        # set only the position in the action, torque is zero by default
+        action = robot_interfaces.finger.Action(position=desired_position)
+        t = finger.append_desired_action(action)
+        finger.wait_until_time_index(t)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -520,16 +520,16 @@ public:
     }
 
     /**
-     * @brief Set same position control gains for all joints.
+     * @brief Set position control gains for all joints.
      *
-     * @param kp P gain.
-     * @param kd D gain.
+     * @param kp P gains.
+     * @param kd D gains.
      */
-    void set_position_control_gains(double kp, double kd)
+    void set_position_control_gains(Vector kp, Vector kd)
     {
         for(size_t i = 0; i < COUNT; i++)
         {
-           set_position_control_gains(i, kp, kd);
+           set_position_control_gains(i, kp[i], kd[i]);
         }
     }
 

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -7,7 +7,9 @@
 
 #pragma once
 
-#include <math.h>
+#include <cmath>
+
+#include <Eigen/Eigen>
 
 #include <mpi_cpp_tools/math.hpp>
 #include <robot_interfaces/n_joint_robot_types.hpp>
@@ -71,18 +73,16 @@ class NJointBlmcRobotDriver
           typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Observation>
 {
 public:
-    typedef
-        typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Action Action;
-    typedef typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Observation
-        Observation;
-    typedef
-        typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Vector Vector;
+    typedef typename robot_interfaces::NJointRobotTypes<N_JOINTS> Types;
+
+    typedef typename Types::Action Action;
+    typedef typename Types::Observation Observation;
+    typedef typename Types::Vector Vector;
     typedef std::array<std::shared_ptr<blmc_drivers::MotorInterface>, N_JOINTS>
         Motors;
     typedef std::array<std::shared_ptr<blmc_drivers::CanBusMotorBoard>,
                        N_MOTOR_BOARDS>
         MotorBoards;
-
 
     /**
      * @brief True if the joints have mechanical end stops, false if not.
@@ -98,12 +98,13 @@ public:
      */
     const bool has_endstop_;
 
-
     NJointBlmcRobotDriver(const MotorBoards &motor_boards,
                           const Motors &motors,
                           const MotorParameters &motor_parameters,
                           const CalibrationParameters &calibration_parameters,
                           const Vector &safety_kd,
+                          const Vector &position_kp,
+                          const Vector &position_kd,
                           const bool has_endstop)
         : robot_interfaces::RobotDriver<Action, Observation>(),
           joint_modules_(motors,
@@ -116,6 +117,8 @@ public:
                          motor_parameters.gear_ratio),
           calibration_parameters_(calibration_parameters),
           safety_kd_(safety_kd),
+          default_position_kp_(position_kp),
+          default_position_kd_(position_kd),
           has_endstop_(has_endstop)
     {
         pause_motors();
@@ -190,15 +193,73 @@ protected:
         double start_time_sec = real_time_tools::Timer::get_current_time_sec();
 
         Observation observation = get_latest_observation();
-        Action applied_action =
-            mct::clamp(desired_action, -max_torque_Nm_, max_torque_Nm_);
-        applied_action =
-            applied_action - safety_kd_.cwiseProduct(observation.velocity);
-        applied_action =
-            mct::clamp(applied_action, -max_torque_Nm_, max_torque_Nm_);
 
-        joint_modules_.set_torques(applied_action);
+        Action applied_action;
+
+        applied_action.torque = desired_action.torque;
+        applied_action.position = desired_action.position;
+
+        // Position controller
+        // -------------------
+        // TODO: add position limits
+        //
+        // NOTE: in the following lines, the Eigen function `unaryExpr` is
+        // used to determine which elements of the vectors are NaN.  This is
+        // because `isNaN()` was only added in Eigen 3.3 but we have to be
+        // compatible with 3.2.
+        // The std::isnan call needs to be wrapped in a lambda because it is
+        // overloaded and unaryExpr cannot resolve which version to use when
+        // passed directly.
+
+        // Run the position controller only if a target position is set for at
+        // least one joint.
+        if (!applied_action.position
+                 .unaryExpr([](double x) { return std::isnan(x); })
+                 .all())
+        {
+            // Replace NaN-values with default gains
+            applied_action.position_kp =
+                applied_action.position_kp
+                    .unaryExpr([](double x) { return std::isnan(x); })
+                    .select(default_position_kp_, desired_action.position_kp);
+            applied_action.position_kd =
+                applied_action.position_kd
+                    .unaryExpr([](double x) { return std::isnan(x); })
+                    .select(default_position_kd_, desired_action.position_kd);
+
+            Vector position_error = applied_action.position - observation.angle;
+
+            // simple PD controller
+            Vector position_control_torque =
+                applied_action.position_kp.cwiseProduct(position_error) +
+                applied_action.position_kd.cwiseProduct(observation.velocity);
+
+            // position_control_torque contains NaN for joints where target
+            // position is set to NaN!  Filter those out and set the torque to
+            // zero instead.
+            position_control_torque =
+                position_control_torque
+                    .unaryExpr([](double x) { return std::isnan(x); })
+                    .select(0, position_control_torque);
+
+            // Add result of position controller to the torque command
+            applied_action.torque += position_control_torque;
+        }
+
+        // Safety Checks
+        // -------------
+        // limit to configured maximum torque
+        applied_action.torque =
+            mct::clamp(applied_action.torque, -max_torque_Nm_, max_torque_Nm_);
+        // velocity damping to prevent too fast movements
+        applied_action.torque -= safety_kd_.cwiseProduct(observation.velocity);
+        // after applying checks, make sure we are still below the max. torque
+        applied_action.torque =
+            mct::clamp(applied_action.torque, -max_torque_Nm_, max_torque_Nm_);
+
+        joint_modules_.set_torques(applied_action.torque);
         joint_modules_.send_torques();
+
         real_time_tools::Timer::sleep_until_sec(start_time_sec + 0.001);
 
         return applied_action;
@@ -311,12 +372,14 @@ protected:
                           const double tolerance,
                           const uint32_t timeout_cycles)
     {
+        // FIXME use position controller through action
         bool reached_goal = false;
         int cycle_count = 0;
         Vector desired_torque = Vector::Zero();
 
         while (!reached_goal && cycle_count < timeout_cycles)
         {
+            // FIXME Why is this compiling?!
             apply_action(desired_torque);
 
             const Vector position_error =
@@ -386,6 +449,11 @@ protected:
 
     //! \brief D-gain to dampen velocity.  Set to zero to disable damping.
     Vector safety_kd_;
+
+    //! \brief default P-gain for position controller.
+    Vector default_position_kp_;
+    //! \brief default D-gain for position controller.
+    Vector default_position_kd_;
 
     /// todo: this should probably go away
     double max_torque_Nm_;

--- a/include/blmc_robots/one_joint_driver.hpp
+++ b/include/blmc_robots/one_joint_driver.hpp
@@ -53,8 +53,6 @@ private:
                                       {
                                           // CalibrationParameters
                                           .torque_ratio = 0.6,
-                                          .control_gain_kp = 3.0,
-                                          .control_gain_kd = 0.03,
                                           .position_tolerance_rad = 0.05,
                                           .move_timeout = 2000,
                                       },

--- a/include/blmc_robots/one_joint_driver.hpp
+++ b/include/blmc_robots/one_joint_driver.hpp
@@ -59,6 +59,8 @@ private:
                                           .move_timeout = 2000,
                                       },
                                       make_vector(0.08),
+                                      make_vector(3.0),
+                                      make_vector(0.03),
                                       true)
     {
         home_offset_rad_ << home_offset_rad;

--- a/include/blmc_robots/real_finger_driver.hpp
+++ b/include/blmc_robots/real_finger_driver.hpp
@@ -45,6 +45,8 @@ private:
                                           .move_timeout = 2000,
                                       },
                                       Vector(0.08, 0.08, 0.04),
+                                      Vector::Ones() * 3.0,
+                                      Vector::Ones() * 0.03,
                                       true)
     {
         home_offset_rad_ << -0.54, -0.17, 0.0;

--- a/include/blmc_robots/real_finger_driver.hpp
+++ b/include/blmc_robots/real_finger_driver.hpp
@@ -39,8 +39,6 @@ private:
                                       {
                                           // CalibrationParameters
                                           .torque_ratio = 0.6,
-                                          .control_gain_kp = 3.0,
-                                          .control_gain_kd = 0.03,
                                           .position_tolerance_rad = 0.05,
                                           .move_timeout = 2000,
                                       },


### PR DESCRIPTION
# Description
Implement a PD position controller in the NJointBlmcRobotDriver that is
executed when passing a target position in the Action.

The controller is executed when applying an action with non-NaN target position. The resulting torque command is added to the torque given in the action.  Position control can be disabled for single joints by setting the target position for this joint to NaN.

Extend real finger demo with position controller: Implement two
functions in the demo: One implementing the position controller in
Python and sending torque commands, the other sending directly position
commands.

Further add a demo `demo_sparse_position_control.py` that shows how to only control position of some joints.

# Do not merge before
https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/6