### PR TITLE
Rename RandomFingerDriver to FakeFingerDriver

### DIFF
--- a/demos/demo_data_logging.py
+++ b/demos/demo_data_logging.py
@@ -10,7 +10,7 @@ import blmc_robots
 def main():
 
     finger_data = robot_interfaces.finger.Data()
-    finger_backend = blmc_robots.create_random_finger_backend(finger_data)
+    finger_backend = blmc_robots.create_fake_finger_backend(finger_data)
     finger = robot_interfaces.finger.Frontend(finger_data)
 
     desired_torque = np.zeros(3)

--- a/demos/demo_fake_finger.py
+++ b/demos/demo_fake_finger.py
@@ -20,7 +20,7 @@ def main():
     # observations from the robot to the data.  Here we use a backend using the
     # "random finger driver" which just provides fake observations and does not
     # need an actual robot to be executed.
-    fake_finger_backend = blmc_robots.create_random_finger_backend(finger_data)
+    fake_finger_backend = blmc_robots.create_fake_finger_backend(finger_data)
 
     # The frontend is used by the user to get observations and send actions
     finger = robot_interfaces.finger.Frontend(finger_data)

--- a/include/blmc_robots/fake_finger_driver.hpp
+++ b/include/blmc_robots/fake_finger_driver.hpp
@@ -6,16 +6,16 @@
 #include <tuple>
 
 #include <blmc_robots/blmc_joint_module.hpp>
-#include "real_time_tools/spinner.hpp"
-#include "real_time_tools/timer.hpp"
 #include <blmc_robots/n_joint_blmc_robot_driver.hpp>
 #include <robot_interfaces/finger_types.hpp>
+#include "real_time_tools/spinner.hpp"
+#include "real_time_tools/timer.hpp"
 
 namespace blmc_robots
 {
-class RandomFingerDriver : public robot_interfaces::RobotDriver<
-                               robot_interfaces::FingerTypes::Action,
-                               robot_interfaces::FingerTypes::Observation>
+class FakeFingerDriver : public robot_interfaces::RobotDriver<
+                             robot_interfaces::FingerTypes::Action,
+                             robot_interfaces::FingerTypes::Observation>
 {
 public:
     typedef robot_interfaces::FingerTypes::Action Action;
@@ -25,10 +25,9 @@ public:
 
     int data_generating_index_ = 0;
 
-    RandomFingerDriver()
+    FakeFingerDriver()
     {
     }
-
 
     Observation get_latest_observation() override
     {
@@ -69,28 +68,27 @@ public:
 
     void initialize() override
     {
-      return;
+        return;
     }
 };
 
-robot_interfaces::FingerTypes::BackendPtr create_random_finger_backend(
+robot_interfaces::FingerTypes::BackendPtr create_fake_finger_backend(
     robot_interfaces::FingerTypes::DataPtr robot_data)
 {
+    // adjusted values
+    constexpr double MAX_ACTION_DURATION_S = 0.03;
+    constexpr double MAX_INTER_ACTION_DURATION_S = 0.05;
 
-  //adjusted values
-  constexpr double MAX_ACTION_DURATION_S = 0.03;
-  constexpr double MAX_INTER_ACTION_DURATION_S = 0.05;
+    std::shared_ptr<robot_interfaces::RobotDriver<
+        robot_interfaces::FingerTypes::Action,
+        robot_interfaces::FingerTypes::Observation>>
+        robot = std::make_shared<FakeFingerDriver>();
 
-  std::shared_ptr<
-      robot_interfaces::RobotDriver<robot_interfaces::FingerTypes::Action,
-                                    robot_interfaces::FingerTypes::Observation>>
-      robot = std::make_shared<RandomFingerDriver>();
+    auto backend = std::make_shared<robot_interfaces::FingerTypes::Backend>(
+        robot, robot_data, MAX_ACTION_DURATION_S, MAX_INTER_ACTION_DURATION_S);
+    backend->set_max_action_repetitions(-1);
 
-  auto backend =
-      std::make_shared<robot_interfaces::FingerTypes::Backend>(robot, robot_data, MAX_ACTION_DURATION_S, MAX_INTER_ACTION_DURATION_S);
-  backend->set_max_action_repetitions(-1);
-
-  return backend;
+    return backend;
 }
 
 }  // namespace blmc_robots

--- a/srcpy/py_real_finger.cpp
+++ b/srcpy/py_real_finger.cpp
@@ -20,7 +20,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
 
-#include <blmc_robots/random_finger_driver.hpp>
+#include <blmc_robots/fake_finger_driver.hpp>
 #include <blmc_robots/real_finger_driver.hpp>
 
 using namespace blmc_robots;
@@ -29,7 +29,7 @@ PYBIND11_MODULE(py_real_finger, m)
 {
     m.def("create_real_finger_backend", &create_real_finger_backend);
 
-    m.def("create_random_finger_backend", &create_random_finger_backend);
+    m.def("create_fake_finger_backend", &create_fake_finger_backend);
 
 }
 


### PR DESCRIPTION
# Description
Rename RandomFingerDriver to FakeFingerDriver. The driver is not really random but returning a sequence of increasing numbers as observations.  Therefore the new name seems more appropriate.

(Sorry, I accidentally added some reformatting to the commit)

Resolves #13.

# How I Tested
By running the logger demo which uses the fake driver.