### PR TITLE
demo_real_finger: Add wait to control loop

### DIFF
--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -69,6 +69,7 @@ def demo_position_commands(finger):
             # executed.
             action = robot_interfaces.finger.Action(position=desired_position)
             t = finger.append_desired_action(action)
+            finger.wait_until_time_index(t)
 
         # print current position from time to time
         print("Position: %s" % finger.get_observation(t).angle)


### PR DESCRIPTION
# Description
Add a `wait_until_time_index` to the position control loop to ensure
that actions are appended at the proper rate.

# How I Tested
By running it on the robot.