### PR TITLE
Set max current from driver to joint modules

### DIFF
--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -340,9 +340,10 @@ public:
           motors,
         const Vector& motor_constants,
         const Vector& gear_ratios,
-        const Vector& zero_angles)
+        const Vector& zero_angles,
+        const Vector& max_currents)
     {
-        set_motor_array(motors, motor_constants, gear_ratios, zero_angles);
+        set_motor_array(motors, motor_constants, gear_ratios, zero_angles, max_currents);
     }
     /**
      * @brief Construct a new BlmcJointModules object
@@ -363,14 +364,17 @@ public:
           motors,
         const Vector& motor_constants,
         const Vector& gear_ratios,
-        const Vector& zero_angles)
+        const Vector& zero_angles,
+        const Vector& max_currents)
     {
         for(size_t i = 0; i < COUNT; i++)
         {
             modules_[i] = std::make_shared<BlmcJointModule>(motors[i],
                                                             motor_constants[i],
                                                             gear_ratios[i],
-                                                            zero_angles[i]);
+                                                            zero_angles[i],
+                                                            false,
+                                                            max_currents[i]);
         }
     }
     /**

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -107,7 +107,8 @@ public:
           joint_modules_(motors,
                          motor_parameters.torque_constant_NmpA * Vector::Ones(),
                          motor_parameters.gear_ratio * Vector::Ones(),
-                         Vector::Zero()),
+                         Vector::Zero(),
+                         motor_parameters.max_current_A * Vector::Ones()),
           motor_boards_(motor_boards),
           max_torque_Nm_(motor_parameters.max_current_A *
                          motor_parameters.torque_constant_NmpA *

--- a/include/blmc_robots/real_disentanglement_platform.hpp
+++ b/include/blmc_robots/real_disentanglement_platform.hpp
@@ -37,7 +37,8 @@ public:
         BlmcJointModules<2>(motors,
                 0.02 * Eigen::Vector2d::Ones(),
                 9.0 * Eigen::Vector2d::Ones(),
-                Eigen::Vector2d::Zero()),
+                Eigen::Vector2d::Zero(),
+                2.0 * Eigen::Vector2d::Ones()),
         sliders_(sliders,
                 Eigen::Vector2d::Zero(),
                 Eigen::Vector2d::Ones()) {}
@@ -82,7 +83,8 @@ private:
         BlmcJointModules<3>(motors,
                 0.02 * Vector::Ones(),
                 Vector(9.79 * 9, 9, 9),
-                Vector::Zero())
+                Vector::Zero(),
+                2.0 * Vector::Ones())
     {
 
 


### PR DESCRIPTION
# Description
As the `NJointBlmcRobotDriver` takes a maximum current parameter as
input, this should also be passed down to the `BlmcJointModule` (which
already has this parameter but so far did not get it set from upstream
and was using the default value instead).

# How I Tested
With demo application on the Finger robot.