### PR TITLE
Load driver configuration from file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ set(CATKIN_PKGS ${CATKIN_PKGS}
 )
 find_package(catkin REQUIRED COMPONENTS ${CATKIN_PKGS})
 
+find_package(yaml-cpp REQUIRED)
+# ${YAML_CPP_INCLUDE_DIR}
+# ${YAML_CPP_LIBRARIES}
+
 # search for the robot_properties package for the demos calibration data
 find_package(robot_properties_solo QUIET)
 find_package(robot_properties_teststand QUIET)
@@ -47,6 +51,7 @@ catkin_python_setup()
 include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${catkin_INCLUDE_DIRS}
+    ${YAML_CPP_INCLUDE_DIR}
     ${Eigen_INCLUDE_DIRS}
 )
 
@@ -63,7 +68,7 @@ set(exported_libraries
 )
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${exported_libraries}
+  LIBRARIES ${exported_libraries} ${YAML_CPP_LIBRARIES}
   CATKIN_DEPENDS ${CATKIN_PKGS}
 )
 
@@ -103,7 +108,7 @@ set(py_real_finger_SRC_FILES
   srcpy/py_real_finger.cpp
 )
 pybind11_add_module(py_real_finger ${py_real_finger_SRC_FILES})
-target_link_libraries(py_real_finger PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(py_real_finger PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 set_target_properties(py_real_finger PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
 install(TARGETS py_real_finger DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
@@ -113,7 +118,7 @@ set(py_one_joint_SRC_FILES
   srcpy/py_one_joint.cpp
 )
 pybind11_add_module(py_one_joint ${py_one_joint_SRC_FILES})
-target_link_libraries(py_one_joint PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(py_one_joint PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 set_target_properties(py_one_joint PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
 install(TARGETS py_one_joint DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
@@ -123,7 +128,7 @@ set(py_two_joint_SRC_FILES
   srcpy/py_two_joint.cpp
 )
 pybind11_add_module(py_two_joint ${py_two_joint_SRC_FILES})
-target_link_libraries(py_two_joint PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(py_two_joint PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 set_target_properties(py_two_joint PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
 install(TARGETS py_two_joint DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})

--- a/config/finger.yml
+++ b/config/finger.yml
@@ -1,0 +1,3 @@
+# Set zero-position according to URDF (finger pointing straight down).
+home_offset_rad: [1.309, 0.873, 2.746]
+initial_position_rad: [0, 0, 0]

--- a/config/finger.yml
+++ b/config/finger.yml
@@ -1,3 +1,15 @@
+can_ports: ["can0", "can1"]
+max_current_A: 2
+has_endstop: true
+calibration:
+    torque_ratio: 0.6
+    position_tolerance_rad: 0.05
+    move_timeout: 2000
+safety_kd: [0.08, 0.08, 0.04]
+position_control_gains:
+    kp: [3, 3, 3]
+    kd: [0.03, 0.03, 0.03]
+
 # Set zero-position according to URDF (finger pointing straight down).
 home_offset_rad: [1.309, 0.873, 2.746]
 initial_position_rad: [0, 0, 0]

--- a/config/finger_legacy.yml
+++ b/config/finger_legacy.yml
@@ -2,7 +2,16 @@
 # With this config, the zero position is at the negative end stop.
 # Use this in case you need the old config for compatibility reasons.
 
-max_current_A: 2.0
+can_ports: ["can0", "can1"]
+max_current_A: 2
+has_endstop: true
+calibration:
+    torque_ratio: 0.6
+    position_tolerance_rad: 0.05
+    move_timeout: 2000
 safety_kd: [0.08, 0.08, 0.04]
+position_control_gains:
+    kp: [3, 3, 3]
+    kd: [0.03, 0.03, 0.03]
 home_offset_rad: [-0.54, -0.17, 0.0]
 initial_position_rad: [1.5, 1.5, 3.0]

--- a/config/finger_legacy.yml
+++ b/config/finger_legacy.yml
@@ -1,0 +1,8 @@
+# Old configuration of the finger robot
+# With this config, the zero position is at the negative end stop.
+# Use this in case you need the old config for compatibility reasons.
+
+max_current_A: 2.0
+safety_kd: [0.08, 0.08, 0.04]
+home_offset_rad: [-0.54, -0.17, 0.0]
+initial_position_rad: [1.5, 1.5, 3.0]

--- a/config/onejoint.yml
+++ b/config/onejoint.yml
@@ -1,0 +1,8 @@
+# can6: MPI board
+# can7: TI Launchpad
+can_ports: ["can6"]
+
+# Offset between encoder index and zero-position (in radian).
+# Set this such that the zero position is in the center between left and
+# right end stop.
+home_offset_rad: [2.241742]

--- a/config/onejoint.yml
+++ b/config/onejoint.yml
@@ -2,7 +2,19 @@
 # can7: TI Launchpad
 can_ports: ["can6"]
 
+max_current_A: 2
+has_endstop: true
+calibration:
+    torque_ratio: 0.6
+    position_tolerance_rad: 0.05
+    move_timeout: 2000
+safety_kd: [0.08]
+position_control_gains:
+    kp: [3]
+    kd: [0.03]
+
 # Offset between encoder index and zero-position (in radian).
 # Set this such that the zero position is in the center between left and
 # right end stop.
 home_offset_rad: [2.241742]
+initial_position_rad: [0.0]

--- a/config/twojoint.yml
+++ b/config/twojoint.yml
@@ -2,7 +2,19 @@
 # can7: TI Launchpad
 can_ports: ["can6"]
 
+max_current_A: 2
+has_endstop: true
+calibration:
+    torque_ratio: 0.6
+    position_tolerance_rad: 0.05
+    move_timeout: 2000
+safety_kd: [0.08, 0.08]
+position_control_gains:
+    kp: [3, 3]
+    kd: [0.03, 0.03]
+
 # Offset between encoder index and zero-position (in radian).
 # Set this such that the zero position is in the center between left and
 # right end stop.
 home_offset_rad: [2.256, 2.2209]
+initial_position_rad: [0, 0]

--- a/config/twojoint.yml
+++ b/config/twojoint.yml
@@ -1,0 +1,8 @@
+# can6: MPI board
+# can7: TI Launchpad
+can_ports: ["can6"]
+
+# Offset between encoder index and zero-position (in radian).
+# Set this such that the zero position is in the center between left and
+# right end stop.
+home_offset_rad: [2.256, 2.2209]

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -21,6 +21,7 @@ macro(create_demo demo_name robot_name)
     ${robot_name}
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
+    ${YAML_CPP_LIBRARIES}
   )
 
   # first look if a robot_properties_${robot_name} package contain a config file.

--- a/demos/demo_finger_print_position.py
+++ b/demos/demo_finger_print_position.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python3
 """Send zero-torque commands to Finger robot and print joint positions."""
+import os
 import numpy as np
+import rospkg
 
 import robot_interfaces
 import blmc_robots
 
+# load the default config file
+config_file_path = os.path.join(
+    rospkg.RosPack().get_path("blmc_robots"), "config", "finger.yml")
 
 finger_data = robot_interfaces.finger.Data()
-finger_backend = blmc_robots.create_real_finger_backend("can0", "can1",
-                                                        finger_data)
+finger_backend = blmc_robots.create_real_finger_backend(finger_data,
+                                                        config_file_path)
 finger = robot_interfaces.finger.Frontend(finger_data)
 
 
 finger_backend.initialize()
-
-# TODO this makes the application hang
-#t = finger.get_current_time_index()
-#print("t = %d" % t)
 
 while True:
     t = finger.append_desired_action(robot_interfaces.finger.Action())

--- a/demos/demo_onejoint_print_position.py
+++ b/demos/demo_onejoint_print_position.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 """Send zero-torque commands to Finger robot and print joint positions."""
+import os
 import numpy as np
+import rospkg
 
 from robot_interfaces import one_joint
 import blmc_robots
 
-home_offset = 2.241742
+# load the default config file
+config_file_path = os.path.join(
+    rospkg.RosPack().get_path("blmc_robots"), "config", "onejoint.yml")
+
 robot_data = one_joint.Data()
-robot_backend = blmc_robots.create_one_joint_backend("can6",
-                                                     home_offset,
-                                                     robot_data)
+robot_backend = blmc_robots.create_one_joint_backend(robot_data,
+                                                     config_file_path)
 robot = one_joint.Frontend(robot_data)
 
 

--- a/demos/demo_onejoint_robot.py
+++ b/demos/demo_onejoint_robot.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Simple demo moving a single joint back and forth."""
-import numpy as np
+import os
 import copy
+import numpy as np
+import rospkg
 
 from robot_interfaces import one_joint
 import blmc_robots
@@ -12,11 +14,6 @@ def main():
     # Configuration
     # ========================================
 
-    # Offset between encoder index and zero-position (in radian).
-    # Set this such that the zero position is in the center between left and
-    # right end stop.
-    home_offset = 2.241742
-
     # Limit of the range in which the joint can move (i.e. should be a little
     # bit before hitting the end stop).
     position_limit = 2.7
@@ -25,14 +22,15 @@ def main():
     kp = 5
     kd = 0.04
 
-
     # ========================================
 
+    # load the default config file
+    config_file_path = os.path.join(
+        rospkg.RosPack().get_path("blmc_robots"), "config", "onejoint.yml")
 
     robot_data = one_joint.Data()
-    robot_backend = blmc_robots.create_one_joint_backend("can6",
-                                                         home_offset,
-                                                         robot_data)
+    robot_backend = blmc_robots.create_one_joint_backend(robot_data,
+                                                         config_file_path)
     robot = one_joint.Frontend(robot_data)
 
 

--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -3,7 +3,9 @@
 
 This script illustrates how to control a robot via the Python interface.
 """
+import os
 import numpy as np
+import rospkg
 
 import robot_interfaces
 import blmc_robots
@@ -77,14 +79,17 @@ def demo_position_commands(finger):
 
 
 def main():
+    # Use the default config file from the blmc_robots package
+    config_file_path = os.path.join(
+        rospkg.RosPack().get_path("blmc_robots"), "config", "finger.yml")
+
     # Storage for all observations, actions, etc.
     finger_data = robot_interfaces.finger.Data()
 
     # The backend sends actions from the data to the robot and writes
     # observations from the robot to the data.
-    real_finger_backend = blmc_robots.create_real_finger_backend("can0",
-                                                                 "can1",
-                                                                 finger_data)
+    real_finger_backend = blmc_robots.create_real_finger_backend(
+        finger_data, config_file_path)
 
     # The frontend is used by the user to get observations and send actions
     finger = robot_interfaces.finger.Frontend(finger_data)

--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -13,8 +13,8 @@ import blmc_robots
 
 def get_random_position():
     """Generate a random position within a save range."""
-    position_min = np.array([1, 0, 0])
-    position_max = np.array([3, 2, 5])
+    position_min = np.array([-1, -1, -2])
+    position_max = np.array([1, 1, 2])
 
     position_range = position_max - position_min
 

--- a/demos/demo_sparse_position_control.py
+++ b/demos/demo_sparse_position_control.py
@@ -4,21 +4,26 @@
 This demo shows how to run a position controller on only the upper two joints
 of the Finger robot while controlling zero-torque on the tip joint.
 """
+import os
 import numpy as np
+import rospkg
 
 import robot_interfaces
 import blmc_robots
 
 
 def main():
+    # load the default config file
+    config_file_path = os.path.join(
+        rospkg.RosPack().get_path("blmc_robots"), "config", "finger.yml")
+
     # Storage for all observations, actions, etc.
     finger_data = robot_interfaces.finger.Data()
 
     # The backend sends actions from the data to the robot and writes
     # observations from the robot to the data.
-    real_finger_backend = blmc_robots.create_real_finger_backend("can0",
-                                                                 "can1",
-                                                                 finger_data)
+    real_finger_backend = blmc_robots.create_real_finger_backend(
+        finger_data, config_file_path)
 
     # The frontend is used by the user to get observations and send actions
     finger = robot_interfaces.finger.Frontend(finger_data)

--- a/demos/demo_twojoint_print_position.py
+++ b/demos/demo_twojoint_print_position.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
 """Send zero-torque commands to Finger robot and print joint positions."""
+import os
 import numpy as np
+import rospkg
 
 from robot_interfaces import two_joint
 import blmc_robots
 
-home_offset = np.array([2.256, 2.2209])
-robot_data = two_joint.Data()
-robot_backend = blmc_robots.create_two_joint_backend("can6",
-                                                     home_offset,
-                                                     robot_data)
+def main():
+    # load the default config file
+    config_file_path = os.path.join(
+        rospkg.RosPack().get_path("blmc_robots"), "config", "twojoint.yml")
 
-robot = two_joint.Frontend(robot_data)
+    robot_data = two_joint.Data()
+    robot_backend = blmc_robots.create_two_joint_backend(robot_data,
+                                                         config_file_path)
 
-robot_backend.initialize()
+    robot = two_joint.Frontend(robot_data)
 
-while True:
-    t = robot.append_desired_action(two_joint.Action())
-    pos = robot.get_observation(t).position
-    print(pos)
+    robot_backend.initialize()
+
+    while True:
+        t = robot.append_desired_action(two_joint.Action())
+        pos = robot.get_observation(t).position
+        print(pos)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/demo_twojoint_robot.py
+++ b/demos/demo_twojoint_robot.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Simple demo moving two joints back and forth."""
+import os
 import numpy as np
 import copy
+import rospkg
 
 from robot_interfaces import two_joint
 import blmc_robots
@@ -12,11 +14,6 @@ def main():
     # Configuration
     # ========================================
 
-    # Offset between encoder index and zero-position (in radian).
-    # Set this such that the zero position is in the center between left and
-    # right end stop.
-    home_offset = np.array([2.256, 2.2209])
-
     # Limit of the range in which the joint can move (i.e. should be a little
     # bit before hitting the end stop).
     position_limit = 2.7
@@ -25,14 +22,15 @@ def main():
     kp = 5
     kd = 0.04
 
-
     # ========================================
 
+    # load the default config file
+    config_file_path = os.path.join(
+        rospkg.RosPack().get_path("blmc_robots"), "config", "twojoint.yml")
 
     robot_data = two_joint.Data()
-    robot_backend = blmc_robots.create_two_joint_backend("can6",
-                                                         home_offset,
-                                                         robot_data)
+    robot_backend = blmc_robots.create_two_joint_backend(robot_data,
+                                                         config_file_path)
     robot = two_joint.Frontend(robot_data)
 
 
@@ -97,7 +95,6 @@ def main():
         goal_position *= -1
         # move to goal position within 2000 ms and wait there for 100 ms
         go_to(goal_position, 2000, 100)
-
 
 
 if __name__ == "__main__":

--- a/include/blmc_robots/one_joint_driver.hpp
+++ b/include/blmc_robots/one_joint_driver.hpp
@@ -7,12 +7,7 @@
 
 #pragma once
 
-#include <math.h>
-#include <Eigen/Eigen>
-#include <blmc_robots/common_header.hpp>
-
 #include <blmc_robots/n_joint_blmc_robot_driver.hpp>
-#include <robot_interfaces/n_joint_robot_types.hpp>
 
 namespace blmc_robots
 {
@@ -24,45 +19,22 @@ namespace blmc_robots
 class OneJointDriver : public NJointBlmcRobotDriver<1, 1>
 {
 public:
-    /**
-     * @brief Constructor
-     *
-     * @param can_port  Name of the CAN port to which the joint is connected
-     *     (e.g. "can0")
-     * @param home_offset_rad  Home offset of the joint.  This is the offset
-     *     between the home position (= encoder index found during homing) and
-     *     the desired zero position.
-     */
-    OneJointDriver(const std::string &can_port,
-                   const double home_offset_rad = 0.0)
-        : OneJointDriver(create_motor_boards({can_port}), home_offset_rad)
+    OneJointDriver(const Config &config)
+        : OneJointDriver(create_motor_boards(config.can_ports), config)
     {
     }
 
 private:
-    OneJointDriver(const MotorBoards &motor_boards,
-                   const double home_offset_rad)
+    OneJointDriver(const MotorBoards &motor_boards, const Config &config)
         : NJointBlmcRobotDriver<1, 1>(motor_boards,
                                       create_motors(motor_boards),
                                       {
                                           // MotorParameters
-                                          .max_current_A = 2.0,
                                           .torque_constant_NmpA = 0.02,
                                           .gear_ratio = 9.0,
                                       },
-                                      {
-                                          // CalibrationParameters
-                                          .torque_ratio = 0.6,
-                                          .position_tolerance_rad = 0.05,
-                                          .move_timeout = 2000,
-                                      },
-                                      make_vector(0.08),
-                                      make_vector(3.0),
-                                      make_vector(0.03),
-                                      true)
+                                      config)
     {
-        home_offset_rad_ << home_offset_rad;
-        initial_position_rad_ << -home_offset_rad;
     }
 
     static Motors create_motors(const MotorBoards &motor_boards)
@@ -73,47 +45,6 @@ private:
 
         return motors;
     }
-
-    /**
-     * @brief Create a Vector with the given value.
-     *
-     * This is a helper function needed for initializing Vectors with a
-     * specific value upon creation.
-     *
-     * @param value Value to be set in the vector.
-     *
-     * @return The Vector.
-     */
-    static Vector make_vector(double value)
-    {
-        Vector vec;
-        vec << value;
-        return vec;
-    }
 };
-
-robot_interfaces::NJointRobotTypes<1>::BackendPtr create_one_joint_backend(
-    const std::string &can_0,
-    const double home_offset_rad,
-    robot_interfaces::NJointRobotTypes<1>::DataPtr robot_data)
-{
-    constexpr double MAX_ACTION_DURATION_S = 0.003;
-    constexpr double MAX_INTER_ACTION_DURATION_S = 0.005;
-
-    std::shared_ptr<robot_interfaces::RobotDriver<
-        robot_interfaces::NJointRobotTypes<1>::Action,
-        robot_interfaces::NJointRobotTypes<1>::Observation>>
-        robot = std::make_shared<OneJointDriver>(can_0, home_offset_rad);
-
-    auto backend =
-        std::make_shared<robot_interfaces::NJointRobotTypes<1>::Backend>(
-            robot,
-            robot_data,
-            MAX_ACTION_DURATION_S,
-            MAX_INTER_ACTION_DURATION_S);
-    backend->set_max_action_repetitions(std::numeric_limits<uint32_t>::max());
-
-    return backend;
-}
 
 }  // namespace blmc_robots

--- a/include/blmc_robots/two_joint_driver.hpp
+++ b/include/blmc_robots/two_joint_driver.hpp
@@ -7,12 +7,7 @@
 
 #pragma once
 
-#include <math.h>
-#include <Eigen/Eigen>
-#include <blmc_robots/common_header.hpp>
-
 #include <blmc_robots/n_joint_blmc_robot_driver.hpp>
-#include <robot_interfaces/n_joint_robot_types.hpp>
 
 namespace blmc_robots
 {
@@ -21,51 +16,25 @@ namespace blmc_robots
  *
  * Driver for a double BLMC joint.  Mostly intended for testing purposes.
  */
-
 class TwoJointDriver : public NJointBlmcRobotDriver<2, 1>
 {
 public:
-    /**
-     * @brief Constructor
-     *
-     * @param can_port  Name of the CAN port to which the joint is connected
-     *     (e.g. "can0")
-     * @param home_offset_rad  Home offset of the joint.  This is the offset
-     *     between the home position (= encoder index found during homing) and
-     *     the desired zero position.
-     */
-
-
-    TwoJointDriver(const std::string &can_port,
-                   Vector &home_offset_rad)
-        : TwoJointDriver(create_motor_boards({can_port}),
-                         home_offset_rad)
+    TwoJointDriver(const Config &config)
+        : TwoJointDriver(create_motor_boards(config.can_ports), config)
     {
     }
 
 private:
-    TwoJointDriver(const MotorBoards &motor_boards,
-                   Vector &home_offset_rad)
+    TwoJointDriver(const MotorBoards &motor_boards, const Config &config)
         : NJointBlmcRobotDriver<2, 1>(motor_boards,
                                       create_motors(motor_boards),
                                       {
                                           // MotorParameters
-                                          .max_current_A = 2.0,
                                           .torque_constant_NmpA = 0.02,
                                           .gear_ratio = 9.0,
                                       },
-                                      {
-                                          // CalibrationParameters
-                                          .torque_ratio = 0.6,
-                                          .position_tolerance_rad = 0.05,
-                                          .move_timeout = 2000,
-                                      },
-                                      Vector(0.08, 0.08),
-                                      Vector(3.0, 3.0),
-                                      Vector(0.03, 0.03),
-                                      true)
+                                      config)
     {
-        home_offset_rad_ << home_offset_rad;
     }
 
     static Motors create_motors(const MotorBoards &motor_boards)
@@ -77,31 +46,7 @@ private:
 
         return motors;
     }
-    
+
 };
-
-robot_interfaces::NJointRobotTypes<2>::BackendPtr create_two_joint_backend(
-    const std::string &can_0,
-    robot_interfaces::NJointRobotTypes<2>::Vector &home_offset_rad,
-    robot_interfaces::NJointRobotTypes<2>::DataPtr robot_data)
-{
-    constexpr double MAX_ACTION_DURATION_S = 0.003;
-    constexpr double MAX_INTER_ACTION_DURATION_S = 0.005;
-
-    std::shared_ptr<robot_interfaces::RobotDriver<
-        robot_interfaces::NJointRobotTypes<2>::Action,
-        robot_interfaces::NJointRobotTypes<2>::Observation>>
-        robot = std::make_shared<TwoJointDriver>(can_0, home_offset_rad);
-
-    auto backend =
-        std::make_shared<robot_interfaces::NJointRobotTypes<2>::Backend>(
-            robot,
-            robot_data,
-            MAX_ACTION_DURATION_S,
-            MAX_INTER_ACTION_DURATION_S);
-    backend->set_max_action_repetitions(std::numeric_limits<uint32_t>::max());
-
-    return backend;
-}
 
 }  // namespace blmc_robots

--- a/package.xml
+++ b/package.xml
@@ -1,34 +1,21 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>blmc_robots</name>
   <version>1.0.0</version>
-  <description>
-    This project implements a small example when using the dynamic graph
-  </description>
+  <description>Interfaces to the BLMC robots.</description>
   <author email="mnaveau@tue.mpg.de">Maximilien Naveau</author>
   <maintainer email="mnaveau@tue.mpg.de">Maximilien Naveau</maintainer>
-  <license>TODO</license>
+  <maintainer email="felix.widmaier@tuebingen.mpg.de">Felix Widmaier</maintainer>
+  <license>BSD 3-clause</license>
+
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend> ati_ft_sensor </build_depend>
-  <run_depend>   ati_ft_sensor </run_depend>
-
-  <build_depend> blmc_drivers </build_depend>
-  <run_depend>   blmc_drivers </run_depend>
-
-  <build_depend> real_time_tools </build_depend>
-  <run_depend>   real_time_tools </run_depend>
-
-  <build_depend> mpi_cmake_modules </build_depend>
-  <run_depend>   mpi_cmake_modules </run_depend>
-
-  <build_depend> robot_interfaces </build_depend>
-  <run_depend>   robot_interfaces </run_depend>
-
-  <build_depend>pybind11_catkin</build_depend>
-  <run_depend>pybind11_catkin</run_depend>
-
-  <build_depend>yaml_cpp_catkin</build_depend>
-  <run_depend>yaml_cpp_catkin</run_depend>
+  <depend>ati_ft_sensor</depend>
+  <depend>blmc_drivers</depend>
+  <depend>real_time_tools</depend>
+  <depend>mpi_cmake_modules</depend>
+  <depend>robot_interfaces</depend>
+  <depend>pybind11_catkin</depend>
+  <depend>yaml_cpp_catkin</depend>
 
 </package>

--- a/scripts/run_onejoint_tests.py
+++ b/scripts/run_onejoint_tests.py
@@ -6,9 +6,8 @@ import copy
 import sys
 from os import path
 
-import threading
-import ipdb
 import progressbar
+import rospkg
 
 from robot_interfaces import one_joint
 import blmc_robots
@@ -21,14 +20,6 @@ N_JOINTS = 1
 
 # Configuration
 # ========================================
-
-# launchpad: can7, custom board: can6
-CAN_PORT = "can6"
-
-# Offset between encoder index and zero-position (in radian).
-# Set this such that the zero position is in the center between left and
-# right end stop.
-HOME_OFFSET = 2.24
 
 # Limit of the range in which the joint can move (i.e. should be a little
 # bit before hitting the end stop).
@@ -261,11 +252,13 @@ def main():
     def log_path(filename):
         return path.join(log_directory, filename)
 
+    # load the default config file
+    config_file_path = path.join(
+        rospkg.RosPack().get_path("blmc_robots"), "config", "onejoint.yml")
 
     robot_data = one_joint.Data()
-    finger_backend = blmc_robots.create_one_joint_backend(CAN_PORT,
-                                                          HOME_OFFSET,
-                                                          robot_data)
+    finger_backend = blmc_robots.create_one_joint_backend(robot_data,
+                                                          config_file_path)
     robot = one_joint.Frontend(robot_data)
     logger = Logger()
 

--- a/srcpy/py_one_joint.cpp
+++ b/srcpy/py_one_joint.cpp
@@ -26,6 +26,6 @@ using namespace blmc_robots;
 
 PYBIND11_MODULE(py_one_joint, m)
 {
-    m.def("create_one_joint_backend", &create_one_joint_backend);
+    m.def("create_one_joint_backend", &create_backend<OneJointDriver>);
 }
 

--- a/srcpy/py_real_finger.cpp
+++ b/srcpy/py_real_finger.cpp
@@ -27,7 +27,7 @@ using namespace blmc_robots;
 
 PYBIND11_MODULE(py_real_finger, m)
 {
-    m.def("create_real_finger_backend", &create_real_finger_backend);
+    m.def("create_real_finger_backend", &create_backend<RealFingerDriver>);
 
     m.def("create_fake_finger_backend", &create_fake_finger_backend);
 

--- a/srcpy/py_two_joint.cpp
+++ b/srcpy/py_two_joint.cpp
@@ -26,6 +26,6 @@ using namespace blmc_robots;
 
 PYBIND11_MODULE(py_two_joint, m)
 {
-    m.def("create_two_joint_backend", &create_two_joint_backend);
+    m.def("create_two_joint_backend", &create_backend<TwoJointDriver>);
 }
 


### PR DESCRIPTION
# Description
Add a `Config` struct to `NJointBlmcRobotDriver` that contains all
configurable parameters.  Actual driver implementations should provide a
method `get_default_config` which returns the default configuration.

A method `load_config` is provided which gets the default configuration
from the driver as well as path to a config file provided by the user.
Loads the config from the file and uses the default values where no
value is given in the file.

Add a print function for easy debugging.

Set C++ standard to 14 as otherwise aggregate initialization is not
possible for a struct that has default values (this is supported by
default GCC on Ubuntu 16.04, so should be no problem).

Add default config files for all current robots in `blmc_robots/config`.
In all the Python demos, use rospack to automatically find the default
config files from the blmc_robots package.

Some refactoring:

- Use a generic, templated `create_backend` function to avoid code
  duplication.


# How I Tested
By running the demos without actual robots and printing the loaded configuration.
I cannot test on the real robots right now because they are in use at the moment but I will do this before merging.


# Do not merge before
~https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/14~