### PR TITLE
Teststand and Solo saturate control

### DIFF
--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -132,6 +132,13 @@ public:
     void send_torque();
 
     /**
+     * @brief Get the max joint torque that can be safely applied
+     * 
+     * @return double 
+     */
+    double get_max_torque() const;
+
+    /**
      * @brief Get the sent joint torque.
      * 
      * @return double (Nm).
@@ -432,6 +439,17 @@ public:
         {
             modules_[i]->set_torque(desired_torques(i));
         }
+    }
+
+
+    Vector get_max_joint_torques()
+    {
+        Vector max_torques;
+        for(size_t i = 0 ; i < COUNT ; ++i)
+        {
+            max_torques[i] = modules_[i]->get_max_torque();
+        }
+        return max_torques;
     }
 
     /**

--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -132,7 +132,7 @@ public:
     void send_torque();
 
     /**
-     * @brief Get the max joint torque that can be safely applied
+     * @brief Get the maximum admissible joint torque that can be applied.
      * 
      * @return double 
      */
@@ -441,8 +441,12 @@ public:
         }
     }
 
-
-    Vector get_max_joint_torques()
+    /**
+     * @brief Get the maximum admissible joint torque that can be applied.
+     * 
+     * @return Vector (N/m)
+     */
+    Vector get_max_torques()
     {
         Vector max_torques;
         for(size_t i = 0 ; i < COUNT ; ++i)

--- a/include/blmc_robots/solo.hpp
+++ b/include/blmc_robots/solo.hpp
@@ -239,7 +239,8 @@ private:
   Vector8d motor_max_current_; /**< Max appliable current before the robot shutdown. */
   Vector8d joint_zero_positions_; /**< Offset to the theoretical "0" pose. */
   Eigen::Array<double, 8, 1> max_joint_torques_; /**< Max joint torques (N/m) */
-  
+  static const double max_joint_torque_security_margin_; /**<  Security margin on the saturation of the control. */
+
   /**
    * Hardware status
    */

--- a/include/blmc_robots/solo.hpp
+++ b/include/blmc_robots/solo.hpp
@@ -238,7 +238,7 @@ private:
   Vector8d joint_gear_ratios_; /**< joint gear ratios (9). */
   Vector8d motor_max_current_; /**< Max appliable current before the robot shutdown. */
   Vector8d joint_zero_positions_; /**< Offset to the theoretical "0" pose. */
-  Eigen::Array<double, 8, 1> max_joint_torques_; /**< Max joint torques (N/m) */
+  Eigen::Array<double, 8, 1> max_joint_torques_; /**< Max joint torques (Nm) */
   static const double max_joint_torque_security_margin_; /**<  Security margin on the saturation of the control. */
 
   /**

--- a/include/blmc_robots/solo.hpp
+++ b/include/blmc_robots/solo.hpp
@@ -238,6 +238,7 @@ private:
   Vector8d joint_gear_ratios_; /**< joint gear ratios (9). */
   Vector8d motor_max_current_; /**< Max appliable current before the robot shutdown. */
   Vector8d joint_zero_positions_; /**< Offset to the theoretical "0" pose. */
+  Eigen::Array<double, 8, 1> max_joint_torques_; /**< Max joint torques (N/m) */
   
   /**
    * Hardware status

--- a/include/blmc_robots/teststand.hpp
+++ b/include/blmc_robots/teststand.hpp
@@ -330,7 +330,7 @@ private:
   Vector2d motor_max_current_;
 
   /**
-   * @brief max_joint_torques_ (N/m)
+   * @brief max_joint_torques_ (Nm)
    */
   Eigen::Array2d max_joint_torques_;
   /**

--- a/include/blmc_robots/teststand.hpp
+++ b/include/blmc_robots/teststand.hpp
@@ -330,6 +330,12 @@ private:
   Vector2d motor_max_current_;
 
   /**
+   * @brief max_joint_torques_ (N/m)
+   * 
+   */
+  Eigen::Array2d max_joint_torques_;
+
+  /**
    * @brief This gives the status (enabled/disabled) of each motors using the
    * joint ordering convention.
    */

--- a/include/blmc_robots/teststand.hpp
+++ b/include/blmc_robots/teststand.hpp
@@ -331,9 +331,12 @@ private:
 
   /**
    * @brief max_joint_torques_ (N/m)
-   * 
    */
   Eigen::Array2d max_joint_torques_;
+  /**
+   * @brief Security margin on the saturation of the control.
+   */
+  static const double max_joint_torque_security_margin_;
 
   /**
    * @brief This gives the status (enabled/disabled) of each motors using the

--- a/src/blmc_joint_module.cpp
+++ b/src/blmc_joint_module.cpp
@@ -60,10 +60,14 @@ void BlmcJointModule::set_joint_polarity(const bool& reverse_polarity)
 {
     polarity_ = reverse_polarity ? -1.0 : 1.0;
 }
-
 void BlmcJointModule::send_torque()
 {
     motor_->send_if_input_changed();
+}
+
+double BlmcJointModule::get_max_torque() const
+{
+    return motor_current_to_joint_torque(max_current_);
 }
 
 double BlmcJointModule::get_sent_torque() const

--- a/src/solo.cpp
+++ b/src/solo.cpp
@@ -3,6 +3,8 @@
 
 namespace blmc_robots{
 
+const double Solo::max_joint_torque_security_margin_ = 0.99;
+
 Solo::Solo()
 {
   /**
@@ -135,7 +137,8 @@ void Solo::initialize()
                           joint_zero_positions_, motor_max_current_);
 
   // Set the maximum joint torque available
-  max_joint_torques_ = 0.99 * joints_.get_max_joint_torques().array();
+  max_joint_torques_ = max_joint_torque_security_margin_ *
+                       joints_.get_max_torques().array();
 
   // The the control gains in order to perform the calibration
   blmc_robots::Vector8d kp, kd;

--- a/src/teststand.cpp
+++ b/src/teststand.cpp
@@ -3,6 +3,8 @@
 
 namespace blmc_robots{
 
+const double Teststand::max_joint_torque_security_margin_ = 0.99;
+
 Teststand::Teststand()
 {
   /**
@@ -78,7 +80,8 @@ void Teststand::initialize()
                           joint_zero_positions_, motor_max_current_);
 
   // set the max torque we saturate to
-  max_joint_torques_ = 0.99 * joints_.get_max_joint_torques().array();
+  max_joint_torques_ = max_joint_torque_security_margin_ *
+                       joints_.get_max_torques().array();
   
   // The the control gains in order to perform the calibration
   Eigen::Vector2d kp, kd;


### PR DESCRIPTION
## What changed?

This PR expose the Maximum joint torque from the joint module.
It uses this data to saturate the control up to 0.99% of the max joint torque for the Teststand and the Solo robot.

## How did I tested it?

- I executed some intense controller on the Teststand and checked the sent control and the executed one.