### PR TITLE
Add Driver and Demo for TriFinger Robot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ set(py_blmc_single_leg_SRC_FILES
   src/single_leg.cpp
   srcpy/py_single_leg.cpp
 )
-
 pybind11_add_module(blmc_single_leg ${py_blmc_single_leg_SRC_FILES})
 target_link_libraries(blmc_single_leg PRIVATE single_leg)
 set_target_properties(blmc_single_leg PROPERTIES
@@ -103,31 +102,28 @@ set_target_properties(blmc_single_leg PROPERTIES
 install(TARGETS blmc_single_leg DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
 
 
-
-set(py_real_finger_SRC_FILES 
-  srcpy/py_real_finger.cpp
-)
-pybind11_add_module(py_real_finger ${py_real_finger_SRC_FILES})
+pybind11_add_module(py_real_finger srcpy/py_real_finger.cpp)
 target_link_libraries(py_real_finger PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 set_target_properties(py_real_finger PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
 install(TARGETS py_real_finger DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
 
 
-set(py_one_joint_SRC_FILES 
-  srcpy/py_one_joint.cpp
-)
-pybind11_add_module(py_one_joint ${py_one_joint_SRC_FILES})
+pybind11_add_module(py_trifinger srcpy/py_trifinger.cpp)
+target_link_libraries(py_trifinger PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
+set_target_properties(py_trifinger PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
+install(TARGETS py_trifinger DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+
+
+pybind11_add_module(py_one_joint srcpy/py_one_joint.cpp)
 target_link_libraries(py_one_joint PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 set_target_properties(py_one_joint PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
 install(TARGETS py_one_joint DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
 
 
-set(py_two_joint_SRC_FILES 
-  srcpy/py_two_joint.cpp
-)
-pybind11_add_module(py_two_joint ${py_two_joint_SRC_FILES})
+pybind11_add_module(py_two_joint srcpy/py_two_joint.cpp)
 target_link_libraries(py_two_joint PRIVATE ${catkin_LIBRARIES} ${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 set_target_properties(py_two_joint PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})

--- a/config/trifinger.yml
+++ b/config/trifinger.yml
@@ -1,0 +1,42 @@
+can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
+max_current_A: 2
+has_endstop: true
+calibration:
+    torque_ratio: 0.6
+    position_tolerance_rad: 0.05
+    move_timeout: 2000
+safety_kd:
+    - 0.08
+    - 0.08
+    - 0.04
+    - 0.08
+    - 0.08
+    - 0.04
+    - 0.08
+    - 0.08
+    - 0.04
+position_control_gains:
+    kp: [3, 3, 3, 3, 3, 3, 3, 3, 3]
+    kd: [0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03]
+
+# Set zero-position according to URDF (finger pointing straight down).
+home_offset_rad:
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+initial_position_rad:
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0

--- a/config/trifinger.yml
+++ b/config/trifinger.yml
@@ -1,8 +1,8 @@
 can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
-max_current_A: 2
+max_current_A: 1.5
 has_endstop: true
 calibration:
-    torque_ratio: 0.6
+    torque_ratio: 1.0
     position_tolerance_rad: 0.05
     move_timeout: 2000
 safety_kd:
@@ -21,22 +21,25 @@ position_control_gains:
 
 # Set zero-position according to URDF (finger pointing straight down).
 home_offset_rad:
-    - 0
-    - 0
-    - 0
-    - 0
-    - 0
-    - 0
-    - 0
-    - 0
-    - 0
+    - 1.390
+    - 1.211
+    - 2.144
+    - 0.983
+    - 1.344
+    - 2.221
+    - 1.038
+    - 1.307
+    - 2.782
+
+# Set the initial position such that it is still save when the stage is at the
+# highest level.
 initial_position_rad:
     - 0
+    - -0.9
+    - -1.7
     - 0
+    - -0.9
+    - -1.7
     - 0
-    - 0
-    - 0
-    - 0
-    - 0
-    - 0
-    - 0
+    - -0.9
+    - -1.7

--- a/demos/demo_onejoint_print_position.py
+++ b/demos/demo_onejoint_print_position.py
@@ -1,26 +1,12 @@
 #!/usr/bin/env python3
-"""Send zero-torque commands to Finger robot and print joint positions."""
-import os
-import numpy as np
-import rospkg
-
-from robot_interfaces import one_joint
+"""Send zero-torque commands to the robot and print joint positions."""
+import robot_interfaces
 import blmc_robots
 
-# load the default config file
-config_file_path = os.path.join(
-    rospkg.RosPack().get_path("blmc_robots"), "config", "onejoint.yml")
+if __name__ == "__main__":
+    robot = blmc_robots.Robot(robot_interfaces.one_joint,
+                              blmc_robots.create_one_joint_backend,
+                              "onejoint.yml")
+    robot.initialize()
 
-robot_data = one_joint.Data()
-robot_backend = blmc_robots.create_one_joint_backend(robot_data,
-                                                     config_file_path)
-robot = one_joint.Frontend(robot_data)
-
-
-robot_backend.initialize()
-
-while True:
-    t = robot.append_desired_action(one_joint.Action())
-    pos = robot.get_observation(t).position
-    #print("\r%6.3f %6.3f %6.3f" % (pos[0], pos[1], pos[2]), end="")
-    print(pos)
+    blmc_robots.demo_print_position(robot)

--- a/demos/demo_trifinger.py
+++ b/demos/demo_trifinger.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Demo script for the TriFinger robot
+
+Moves the TriFinger robot with a hard-coded choreography for show-casing and
+testing.
+"""
+import time
+import numpy as np
+
+import robot_interfaces
+import blmc_robots
+
+
+N_JOINTS = 9
+
+
+def run_choreography(robot):
+    """Move the legs in some hard-coded choreography."""
+
+    def perform_step(position):
+        t = robot.frontend.append_desired_action(robot.Action(position=position))
+        time.sleep(1)
+
+    deg45 = np.pi / 4
+
+    while True:
+        perform_step([
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+        ])
+
+        perform_step([
+            0, +deg45, +deg45,
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+        ])
+
+        perform_step([
+            0, -deg45, -deg45,
+            0, +deg45, +deg45,
+            0, -deg45, -deg45,
+        ])
+
+        perform_step([
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+            0, +deg45, +deg45,
+        ])
+
+        perform_step([
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+        ])
+
+        perform_step([
+            -deg45, -deg45, -deg45,
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+        ])
+
+        perform_step([
+            0, -deg45, -deg45,
+            -deg45, -deg45, -deg45,
+            0, -deg45, -deg45,
+        ])
+
+        perform_step([
+            0, -deg45, -deg45,
+            0, -deg45, -deg45,
+            -deg45, -deg45, -deg45,
+        ])
+
+
+def main():
+    robot = blmc_robots.Robot(robot_interfaces.trifinger,
+                              blmc_robots.create_trifinger_backend,
+                              "trifinger.yml")
+    robot.initialize()
+
+    # move around
+    run_choreography(robot)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/demos/demo_trifinger_print_position.py
+++ b/demos/demo_trifinger_print_position.py
@@ -4,9 +4,9 @@ import robot_interfaces
 import blmc_robots
 
 if __name__ == "__main__":
-    robot = blmc_robots.Robot(robot_interfaces.finger,
-                              blmc_robots.create_real_finger_backend,
-                              "finger.yml")
+    robot = blmc_robots.Robot(robot_interfaces.trifinger,
+                              blmc_robots.create_trifinger_backend,
+                              "trifinger.yml")
     robot.initialize()
 
     blmc_robots.demo_print_position(robot)

--- a/demos/demo_twojoint_print_position.py
+++ b/demos/demo_twojoint_print_position.py
@@ -1,30 +1,12 @@
 #!/usr/bin/env python3
-"""Send zero-torque commands to Finger robot and print joint positions."""
-import os
-import numpy as np
-import rospkg
-
-from robot_interfaces import two_joint
+"""Send zero-torque commands to the robot and print joint positions."""
+import robot_interfaces
 import blmc_robots
 
-def main():
-    # load the default config file
-    config_file_path = os.path.join(
-        rospkg.RosPack().get_path("blmc_robots"), "config", "twojoint.yml")
-
-    robot_data = two_joint.Data()
-    robot_backend = blmc_robots.create_two_joint_backend(robot_data,
-                                                         config_file_path)
-
-    robot = two_joint.Frontend(robot_data)
-
-    robot_backend.initialize()
-
-    while True:
-        t = robot.append_desired_action(two_joint.Action())
-        pos = robot.get_observation(t).position
-        print(pos)
-
-
 if __name__ == "__main__":
-    main()
+    robot = blmc_robots.Robot(robot_interfaces.two_joint,
+                              blmc_robots.create_two_joint_backend,
+                              "twojoint.yml")
+    robot.initialize()
+
+    blmc_robots.demo_print_position(robot)

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -518,6 +518,7 @@ protected:
         // TODO distance limit could be set based on gear ratio to be 1.5 motor
         // revolutions
 
+        rt_printf("Start homing.\n");
         if (has_endstop_)
         {
             //! Min. number of steps when moving to the end stop.
@@ -525,7 +526,7 @@ protected:
             //! Size of the window when computing average velocity.
             constexpr uint32_t SIZE_VELOCITY_WINDOW = 100;
             //! Velocity limit at which the joints are considered to be stopped
-            constexpr double STOP_VELOCITY = 0.001;
+            constexpr double STOP_VELOCITY = 0.005;
 
             static_assert(MIN_STEPS_MOVE_TO_END_STOP > SIZE_VELOCITY_WINDOW,
                           "MIN_STEPS_MOVE_TO_END_STOP has to be bigger than"
@@ -555,7 +556,17 @@ protected:
                 running_velocities[running_index] = abs_velocities;
                 summed_velocities += abs_velocities;
                 step_count++;
+
+#ifdef VERBOSE
+                Eigen::IOFormat commainitfmt(
+                    4, Eigen::DontAlignCols, " ", " ", "", "", "", "");
+                std::cout << ((summed_velocities / SIZE_VELOCITY_WINDOW)
+                                  .array() > STOP_VELOCITY)
+                                 .format(commainitfmt)
+                          << std::endl;
+#endif
             }
+            rt_printf("Reached end stop.\n");
         }
 
         // Home on encoder index

--- a/include/blmc_robots/trifinger_driver.hpp
+++ b/include/blmc_robots/trifinger_driver.hpp
@@ -1,0 +1,59 @@
+/**
+ * \file
+ * \brief The hardware wrapper of the real TriFinger robot.
+ * \copyright Copyright (c) 2019, New York University and Max Planck
+ *            Gesellschaft.
+ */
+
+#pragma once
+
+#include <robot_interfaces/trifinger_types.hpp>
+#include <blmc_robots/n_joint_blmc_robot_driver.hpp>
+
+namespace blmc_robots
+{
+class TriFingerDriver : public NJointBlmcRobotDriver<9, 6>
+{
+public:
+    TriFingerDriver(const Config &config)
+        : TriFingerDriver(create_motor_boards(config.can_ports), config)
+    {
+    }
+
+private:
+    TriFingerDriver(const MotorBoards &motor_boards, const Config &config)
+        : NJointBlmcRobotDriver<9, 6>(motor_boards,
+                                      create_motors(motor_boards),
+                                      {
+                                          // MotorParameters
+                                          .torque_constant_NmpA = 0.02,
+                                          .gear_ratio = 9.0,
+                                      },
+                                      config)
+    {
+    }
+
+    static Motors create_motors(const MotorBoards &motor_boards)
+    {
+        Motors motors;
+
+        // there are three fingers
+        // each finger has three motors and two boards
+        motors[0] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 0);
+        motors[1] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 1);
+        motors[2] = std::make_shared<blmc_drivers::Motor>(motor_boards[1], 0);
+
+        motors[3] = std::make_shared<blmc_drivers::Motor>(motor_boards[2], 0);
+        motors[4] = std::make_shared<blmc_drivers::Motor>(motor_boards[2], 1);
+        motors[5] = std::make_shared<blmc_drivers::Motor>(motor_boards[3], 0);
+
+        motors[6] = std::make_shared<blmc_drivers::Motor>(motor_boards[4], 0);
+        motors[7] = std::make_shared<blmc_drivers::Motor>(motor_boards[4], 1);
+        motors[8] = std::make_shared<blmc_drivers::Motor>(motor_boards[5], 0);
+
+        return motors;
+    }
+};
+
+}  // namespace blmc_robots
+

--- a/python/blmc_robots/__init__.py
+++ b/python/blmc_robots/__init__.py
@@ -1,3 +1,5 @@
+from blmc_robots.robot import Robot, demo_print_position
+
 from blmc_robots.blmc_single_leg import *
 from blmc_robots.py_real_finger import *
 from blmc_robots.py_trifinger import *

--- a/python/blmc_robots/__init__.py
+++ b/python/blmc_robots/__init__.py
@@ -1,4 +1,5 @@
 from blmc_robots.blmc_single_leg import *
 from blmc_robots.py_real_finger import *
+from blmc_robots.py_trifinger import *
 from blmc_robots.py_one_joint import *
 from blmc_robots.py_two_joint import *

--- a/python/blmc_robots/robot.py
+++ b/python/blmc_robots/robot.py
@@ -1,0 +1,54 @@
+"""Classes and functions to easily set up robot demo scripts."""
+import os
+import rospkg
+
+
+class Robot:
+
+    def __init__(self, robot_module, create_backend_function, config_file_name):
+        """Initialize the robot environment (backend and frontend).
+
+        :param robot_module: The module that defines the robot classes (i.e.
+            `Data`, `Frontend`, `Backend`, ...)
+        :param create_backend_function: Function to create the robot backend.
+        :param config_file_name: Name of the config file (expected to be
+            located in blmc_robots/config).
+        """
+        # convenience mapping of the Action type
+        self.Action = robot_module.Action
+
+        # Use the default config file from the blmc_robots package
+        config_file_path = os.path.join(
+            rospkg.RosPack().get_path("blmc_robots"), "config",
+            config_file_name)
+
+        # Storage for all observations, actions, etc.
+        self.robot_data = robot_module.Data()
+
+        # The backend sends actions from the data to the robot and writes
+        # observations from the robot to the data.
+        self.backend = create_backend_function(self.robot_data,
+                                               config_file_path)
+
+        # The frontend is used by the user to get observations and send actions
+        self.frontend = robot_module.Frontend(self.robot_data)
+
+    def initialize(self):
+        """Initialize the robot."""
+        # Initializes the robot (e.g. performs homing).
+        self.backend.initialize()
+
+
+def demo_print_position(robot):
+    """Send zero-torque commands to the robot and print the joint positions.
+
+    :param robot: The robot environment.
+    :type robot: Robot
+    """
+    action = robot.Action()
+    while True:
+        t = robot.frontend.append_desired_action(action)
+        pos = robot.frontend.get_observation(t).position
+        n_joints = len(pos)
+        format_string = "\r" + ", ".join(["{: 6.3f}"] * n_joints)
+        print(format_string.format(*pos), end="")

--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright [2017] Max Planck Society. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <pybind11/eigen.h>
+#include <pybind11/embed.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+
+#include <blmc_robots/trifinger_driver.hpp>
+
+using namespace blmc_robots;
+
+PYBIND11_MODULE(py_trifinger, m)
+{
+    m.def("create_trifinger_backend", &create_backend<TriFingerDriver>);
+}
+


### PR DESCRIPTION
# Description
- Add a driver for the TriFinger robot based on NJointBlmcRobotDriver.
- Add a default config file with reduced max. current (1.5A) to be very careful in the beginning.
- Increase the "stop velocity" threshold for homing a bit (the old value was very borderline and with nine joints there is just always one joint which was above).
- Increase the CAN receive timeout from 10ms to 50ms.  For currently unknown reason there are sometimes delays exceeding the 10ms during homing (just a workaround, the issue should be fixed and the timeout set back to its original value).
- Add a demo script that moves all three fingers in a hard-coded choreography.
- Generalize the "print position" demos of all the robots and add one for the TriFinger.

# How I Tested
https://owncloud.tuebingen.mpg.de/index.php/s/2aZFLqr8aAQQ9GL

# Do Not Merge Before
https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/21