### PR TITLE
Export blmc_robots library and yaml-cpp dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ include_directories(
 # export the package as a catkin package #
 ##########################################
 set(exported_libraries
+  ${PROJECT_NAME}
   test_bench_8_motors
   solo
   teststand
@@ -68,8 +69,9 @@ set(exported_libraries
 )
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${exported_libraries} ${YAML_CPP_LIBRARIES}
+  LIBRARIES ${exported_libraries}
   CATKIN_DEPENDS ${CATKIN_PKGS}
+  DEPENDS yaml-cpp
 )
 
 ########################################################

--- a/package.xml
+++ b/package.xml
@@ -18,4 +18,7 @@
   <depend>pybind11_catkin</depend>
   <depend>yaml_cpp_catkin</depend>
 
+  <depend>eigen</depend>
+  <depend>yaml-cpp</depend>
+
 </package>


### PR DESCRIPTION
- The blmc_robots library needs to be exported so other packages can
  actually use it.
- Adding `DEPENDS yaml-cpp` seems to be the cleaner way compared to
  adding it to `LIBRARIES`.