### PR TITLE
Remove unused typedef

### DIFF
--- a/include/blmc_robots/fake_finger_driver.hpp
+++ b/include/blmc_robots/fake_finger_driver.hpp
@@ -21,7 +21,6 @@ public:
     typedef robot_interfaces::FingerTypes::Action Action;
     typedef robot_interfaces::FingerTypes::Observation Observation;
     typedef robot_interfaces::FingerTypes::Vector Vector;
-    typedef robot_interfaces::FingerTypes::Status Status;
 
     int data_generating_index_ = 0;
 


### PR DESCRIPTION
The `Status` was renamed to `RobotStatus` in the types struct recently.
Since it is anyway not used here, simply remove the typedef completely.