### PR TITLE
Add implementation for RobotDriver::get_error()

### DIFF
--- a/include/blmc_robots/fake_finger_driver.hpp
+++ b/include/blmc_robots/fake_finger_driver.hpp
@@ -60,6 +60,11 @@ public:
         return desired_action;
     }
 
+    std::string get_error() override
+    {
+        return "";  // no errors
+    }
+
     void shutdown() override
     {
         return;


### PR DESCRIPTION
# Description
Implement `get_error()` for the `NJointBlmcRobotDriver`. Checks if any motor board reports an error and, if yes, translates the error code to an understandable error message.

# Do not merge before
https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/30 (should be merged together)