### PR TITLE
Adjust to name changes of RobotData

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -708,7 +708,7 @@ public:
 
 template <typename Driver>
 typename Driver::Types::BackendPtr create_backend(
-    typename Driver::Types::DataPtr robot_data,
+    typename Driver::Types::BaseDataPtr robot_data,
     const std::string &config_file_path)
 {
     constexpr double MAX_ACTION_DURATION_S = 0.003;


### PR DESCRIPTION
# Description

The backend now takes a `BaseDataPtr` so both single- and multi-process
version can be used.

# How I Tested
By running demo_fake_finger.py with both single- and multi-process versions.
Further running all the other Python demos but without robot connected (i.e. ensured everything works to the point where it fails because there is no robot).

# Do not merge before
https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/36