### PR TITLE
Add missing dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ set(CATKIN_PKGS ${CATKIN_PKGS}
   robot_interfaces
   pybind11_catkin
   yaml_cpp_catkin
+  robot_properties_solo
+  robot_properties_teststand
 )
 find_package(catkin REQUIRED COMPONENTS ${CATKIN_PKGS})
 

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <depend>robot_interfaces</depend>
   <depend>pybind11_catkin</depend>
   <depend>yaml_cpp_catkin</depend>
+  <depend>robot_properties_solo</depend>
+  <depend>robot_properties_teststand</depend>
 
   <depend>eigen</depend>
   <depend>yaml-cpp</depend>


### PR DESCRIPTION
## Description

robot_properties_solo and _teststand are needed to build the demos but were not specified as dependencies before.


## How I Tested

    catkin build blmc_robots


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
