### PR TITLE
Move implementations of NJointBlmcRobotDriver to hxx file

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -84,224 +84,7 @@ public:
                        N_MOTOR_BOARDS>
         MotorBoards;
 
-    /**
-     * @brief Configuration of the robot that can be changed by the user.
-     */
-    struct Config
-    {
-        typedef std::array<std::string, N_MOTOR_BOARDS> CanPortArray;
-
-        // All parameters should have default values that should not result in
-        // dangerous behaviour in case someone forgets to specify them.
-
-        /**
-         * @brief List of CAN port names used by the robot.
-         *
-         * For each motor control board used by the robot, this specifies the
-         * CAN port through which it is connected.
-         *
-         * Example: `{"can0", "can1"}`
-         */
-        CanPortArray can_ports;
-
-        //! @brief Maximum current that can be sent to the motor [A].
-        double max_current_A = 0.0;
-
-        /**
-         * @brief Whether the joints have physical end stops or not.
-         *
-         * This is for example relevant for homing, where (in case this value
-         * is set to true) all joints move until they hit the end stop to
-         * determine their absolute position.
-         *
-         * Note that not having end stops does not mean that the joint can
-         * rotate freely in general.
-         */
-        bool has_endstop = false;
-
-        //! @brief Parameters related to calibration.
-        CalibrationParameters calibration = {
-            .endstop_search_torque_Nm = 0.0,
-            .position_tolerance_rad = 0.0,
-            .move_timeout = 0,
-        };
-
-        //! \brief D-gain to dampen velocity.  Set to zero to disable damping.
-        // set some rather high damping by default
-        Vector safety_kd = Vector::Constant(0.1);
-
-        //! @brief Default control gains for the position PD controller.
-        struct
-        {
-            Vector kp = Vector::Zero();
-            Vector kd = Vector::Zero();
-        } position_control_gains;
-
-        //! \brief Offset between home position and zero.
-        Vector home_offset_rad = Vector::Zero();
-
-        /**
-         * @brief Initial position to which the robot moves after
-         *        initialization.
-         */
-        Vector initial_position_rad = Vector::Zero();
-
-        /**
-         * @brief Print the given configuration in a human-readable way.
-         */
-        void print() const
-        {
-            std::cout << "Configuration:\n"
-                      << "\t can_ports:";
-            for (const auto &port : can_ports)
-            {
-                std::cout << " " << port;
-            }
-            std::cout << "\n"
-                      << "\t max_current_A: " << max_current_A << "\n"
-                      << "\t has_endstop: " << has_endstop << "\n"
-                      << "\t calibration: "
-                      << "\n"
-                      << "\t\t endstop_search_torque_Nm: "
-                      << calibration.endstop_search_torque_Nm << "\n"
-                      << "\t\t position_tolerance_rad: "
-                      << calibration.position_tolerance_rad << "\n"
-                      << "\t\t move_timeout: " << calibration.move_timeout
-                      << "\n"
-                      << "\t safety_kd: " << safety_kd.transpose() << "\n"
-                      << "\t position_control_gains: "
-                      << "\n"
-                      << "\t\t kp: " << position_control_gains.kp.transpose()
-                      << "\n"
-                      << "\t\t kd: " << position_control_gains.kd.transpose()
-                      << "\n"
-                      << "\t home_offset_rad: " << home_offset_rad.transpose()
-                      << "\n"
-                      << "\t initial_position_rad: "
-                      << initial_position_rad.transpose() << "\n"
-                      << std::endl;
-        }
-
-        /**
-         * @brief Load driver configuration from file.
-         *
-         * Load the configuration from the specified YAML file.  The file is
-         * expected to have the same structure/key naming as the Config struct.
-         * If a value can not be read from the file, the application exists
-         * with an error message.
-         *
-         * @param config_file_name  Path/name of the configuration YAML file.
-         *
-         * @return Configuration
-         */
-        static Config load_config(const std::string &config_file_name)
-        {
-            Config config;
-            YAML::Node user_config;
-
-            try
-            {
-                user_config = YAML::LoadFile(config_file_name);
-            }
-            catch (...)
-            {
-                std::cout << "FATAL: Failed to load configuration from '"
-                          << config_file_name << "'." << std::endl;
-                std::exit(1);
-            }
-
-            // replace values from the default config with the ones given in the
-            // users config file
-
-            // TODO: for some reason direct conversion is not working (despite
-            // yaml-cpp implementing a generic conversion for std::array)
-            // set_config_value<CanPortArray>(user_config, "can_ports",
-            // &config.can_ports);
-            try
-            {
-                for (size_t i = 0; i < config.can_ports.size(); i++)
-                {
-                    config.can_ports[i] =
-                        user_config["can_ports"][i].as<std::string>();
-                }
-            }
-            catch (...)
-            {
-                std::cerr << "FATAL: Failed to load parameter 'can_ports' from "
-                             "configuration file"
-                          << std::endl;
-                std::exit(1);
-            }
-
-            set_config_value(
-                user_config, "max_current_A", &config.max_current_A);
-            set_config_value(user_config, "has_endstop", &config.has_endstop);
-
-            if (user_config["calibration"])
-            {
-                YAML::Node calib = user_config["calibration"];
-
-                set_config_value(calib,
-                                 "endstop_search_torque_Nm",
-                                 &config.calibration.endstop_search_torque_Nm);
-                set_config_value(calib,
-                                 "position_tolerance_rad",
-                                 &config.calibration.position_tolerance_rad);
-                set_config_value(
-                    calib, "move_timeout", &config.calibration.move_timeout);
-            }
-
-            set_config_value(user_config, "safety_kd", &config.safety_kd);
-
-            if (user_config["position_control_gains"])
-            {
-                YAML::Node pos_ctrl = user_config["position_control_gains"];
-
-                set_config_value(
-                    pos_ctrl, "kp", &config.position_control_gains.kp);
-                set_config_value(
-                    pos_ctrl, "kd", &config.position_control_gains.kd);
-            }
-
-            set_config_value(
-                user_config, "home_offset_rad", &config.home_offset_rad);
-            set_config_value(user_config,
-                             "initial_position_rad",
-                             &config.initial_position_rad);
-
-            return config;
-        }
-
-    private:
-        /**
-         * \brief Set value from user configuration to var if specified.
-         *
-         * Checks if a field `name` exists in `user_config`.  If yes, its value
-         * is written to `var`, otherwise `var` is unchanged.
-         *
-         * \param[in] user_config  YAML node containing the user configuration.
-         * \param[in] name  Name of the configuration entry.
-         * \param[out] var  Variable to which configuration is written.  Value
-         * is unchanged if the specified field name does not exist in
-         * user_config, i.e.  it can be initialized with a default value.
-         */
-        template <typename T>
-        static void set_config_value(const YAML::Node &user_config,
-                                     const std::string &name,
-                                     T *var)
-        {
-            try
-            {
-                *var = user_config[name].as<T>();
-            }
-            catch (const YAML::Exception &e)
-            {
-                std::cerr << "FATAL: Failed to load parameter '" << name
-                          << "' from configuration file" << std::endl;
-                std::exit(1);
-            };
-        }
-    };
+    struct Config;  // actual declaration see below
 
     /**
      * @brief True if the joints have mechanical end stops, false if not.
@@ -339,116 +122,16 @@ public:
     }
 
     static MotorBoards create_motor_boards(
-        const std::array<std::string, N_MOTOR_BOARDS> &can_ports)
+        const std::array<std::string, N_MOTOR_BOARDS> &can_ports);
+
+    Vector get_max_torques() const
     {
-        // setup can buses -----------------------------------------------------
-        std::array<std::shared_ptr<blmc_drivers::CanBus>, N_MOTOR_BOARDS>
-            can_buses;
-        for (size_t i = 0; i < can_buses.size(); i++)
-        {
-            can_buses[i] = std::make_shared<blmc_drivers::CanBus>(can_ports[i]);
-        }
-
-        // set up motor boards -------------------------------------------------
-        MotorBoards motor_boards;
-        for (size_t i = 0; i < motor_boards.size(); i++)
-        {
-            motor_boards[i] = std::make_shared<blmc_drivers::CanBusMotorBoard>(
-                can_buses[i], 1000, 10);
-            /// \TODO: reduce the timeout further!!
-        }
-
-        for (size_t i = 0; i < motor_boards.size(); i++)
-        {
-            motor_boards[i]->wait_until_ready();
-        }
-
-        return motor_boards;
+        return max_torque_Nm_ * Vector::Ones();
     }
 
-    void pause_motors()
-    {
-        for (size_t i = 0; i < motor_boards_.size(); i++)
-        {
-            motor_boards_[i]->pause_motors();
-        }
-    }
+    void pause_motors();
 
-    Vector get_measured_index_angles() const
-    {
-        return joint_modules_.get_measured_index_angles();
-    }
-
-    Observation get_latest_observation() override
-    {
-        Observation observation;
-        observation.position = joint_modules_.get_measured_angles();
-        observation.velocity = joint_modules_.get_measured_velocities();
-        observation.torque = joint_modules_.get_measured_torques();
-        return observation;
-    }
-
-    std::string get_error() override
-    {
-        // Checks each board for errors and translates the error codes into
-        // human-readable strings.  If multiple boards have errors, the messages
-        // are concatenated.  Each message is prepended with the index of the
-        // corresponding board.
-
-        std::string error_msg = "";
-
-        for (size_t i = 0; i < motor_boards_.size(); i++)
-        {
-            auto status_timeseries = motor_boards_[i]->get_status();
-            if (status_timeseries->length() > 0)
-            {
-                std::string board_error_msg = "";
-                using ErrorCodes = blmc_drivers::MotorBoardStatus::ErrorCodes;
-                switch (status_timeseries->newest_element().error_code)
-                {
-                    case ErrorCodes::NONE:
-                        break;
-                    case ErrorCodes::ENCODER:
-                        board_error_msg = "Encoder Error";
-                        break;
-                    case ErrorCodes::CAN_RECV_TIMEOUT:
-                        board_error_msg = "CAN Receive Timeout";
-                        break;
-                    case ErrorCodes::CRIT_TEMP:
-                        board_error_msg = "Critical Temperature";
-                        break;
-                    case ErrorCodes::POSCONV:
-                        board_error_msg =
-                            "Error in SpinTAC Position Convert module";
-                        break;
-                    case ErrorCodes::POS_ROLLOVER:
-                        board_error_msg = "Position Rollover";
-                        break;
-                    case ErrorCodes::OTHER:
-                        board_error_msg = "Other Error";
-                        break;
-                    default:
-                        board_error_msg = "Unknown Error";
-                        break;
-                }
-
-                if (!board_error_msg.empty())
-                {
-                    if (!error_msg.empty())
-                    {
-                        error_msg += "  ";
-                    }
-
-                    // error of the board with board index to the error message
-                    // string
-                    error_msg +=
-                        "[Board " + std::to_string(i) + "] " + board_error_msg;
-                }
-            }
-        }
-
-        return error_msg;
-    }
+    Vector get_measured_index_angles() const;
 
     /**
      * @brief Find home position of all joints and move to start position.
@@ -458,67 +141,38 @@ public:
      * `config_.initial_position_rad`).
      *
      */
-    void initialize() override
-    {
-        // Initialization is moving the robot and thus needs to be executed in
-        // a real-time thread.  This method only starts the thread and waits
-        // for it to finish.  Actual implementation of initialization is in
-        // `_initialize()`.
+    void initialize() override;
 
-        real_time_tools::RealTimeThread realtime_thread;
-        realtime_thread.create_realtime_thread(
-            [](void *instance_pointer) {
-                // instance_pointer = this, cast to correct type and call the
-                // _initialize() method.
-                ((NJointBlmcRobotDriver<N_JOINTS, N_MOTOR_BOARDS>
-                      *)(instance_pointer))
-                    ->_initialize();
-                return (void *)nullptr;
-            },
-            this);
-        realtime_thread.join();
-    }
-
-    void shutdown() override
-    {
-        pause_motors();
-    }
-
-    Action apply_action(const Action &desired_action) override
-    {
-        if (!is_initialized_)
-        {
-            throw std::runtime_error(
-                "Robot needs to be initialized before applying actions.  Run "
-                "the `initialize()` method.");
-        }
-
-        return apply_action_uninitialized(desired_action);
-    }
+    Observation get_latest_observation() override;
+    Action apply_action(const Action &desired_action) override;
+    std::string get_error() override;
+    void shutdown() override;
 
 protected:
-    Action apply_action_uninitialized(const Action &desired_action)
-    {
-        double start_time_sec = real_time_tools::Timer::get_current_time_sec();
+    BlmcJointModules<N_JOINTS> joint_modules_;
+    MotorBoards motor_boards_;
 
-        Observation observation = get_latest_observation();
+    //! \brief Fixed motor parameters (assuming all joints use same setup).
+    MotorParameters motor_parameters_;
 
-        Action applied_action =
-            robot_interfaces::NJointRobotFunctions<N_JOINTS>::
-                process_desired_action(desired_action,
-                                       observation,
-                                       max_torque_Nm_,
-                                       config_.safety_kd,
-                                       config_.position_control_gains.kp,
-                                       config_.position_control_gains.kd);
+    //! \brief Maximum torque allowed on each joint.
+    double max_torque_Nm_;
 
-        joint_modules_.set_torques(applied_action.torque);
-        joint_modules_.send_torques();
+    /**
+     * \brief User-defined configuration of the driver
+     *
+     * Contains all configuration values that can be modified by the user (via
+     * the configuration file).
+     */
+    Config config_;
 
-        real_time_tools::Timer::sleep_until_sec(start_time_sec + 0.001);
+    bool is_initialized_ = false;
 
-        return applied_action;
-    }
+    Action apply_action_uninitialized(const Action &desired_action);
+
+    //! \brief Actual initialization that is called in a real-time thread in
+    //!        initialize().
+    void _initialize();
 
     /**
      * @brief Homing on negative end stop and encoder index.
@@ -547,72 +201,7 @@ protected:
      */
     bool home_on_index_after_negative_end_stop(
         double endstop_search_torque_Nm,
-        Vector home_offset_rad = Vector::Zero())
-    {
-        //! Distance after which encoder index search is aborted.
-        //! Computed based on gear ratio to be 1.5 motor revolutions.
-        const double SEARCH_DISTANCE_LIMIT_RAD =
-            (1.5 / motor_parameters_.gear_ratio) * 2 * M_PI;
-
-        rt_printf("Start homing.\n");
-        if (has_endstop_)
-        {
-            //! Min. number of steps when moving to the end stop.
-            constexpr uint32_t MIN_STEPS_MOVE_TO_END_STOP = 1000;
-            //! Size of the window when computing average velocity.
-            constexpr uint32_t SIZE_VELOCITY_WINDOW = 100;
-            //! Velocity limit at which the joints are considered to be stopped
-            constexpr double STOP_VELOCITY = 0.01;
-
-            static_assert(MIN_STEPS_MOVE_TO_END_STOP > SIZE_VELOCITY_WINDOW,
-                          "MIN_STEPS_MOVE_TO_END_STOP has to be bigger than"
-                          " SIZE_VELOCITY_WINDOW to ensure correct computation"
-                          " of average velocity.");
-
-            // Move until velocity drops to almost zero (= joints hit the end
-            // stops) but at least for MIN_STEPS_MOVE_TO_END_STOP time steps.
-            // TODO: add timeout to this loop?
-            std::vector<Vector> running_velocities(SIZE_VELOCITY_WINDOW);
-            Vector summed_velocities = Vector::Zero();
-            uint32_t step_count = 0;
-            while (step_count < MIN_STEPS_MOVE_TO_END_STOP ||
-                   (summed_velocities.maxCoeff() / SIZE_VELOCITY_WINDOW >
-                    STOP_VELOCITY))
-            {
-                Vector torques = Vector::Constant(-endstop_search_torque_Nm);
-                apply_action_uninitialized(torques);
-                Vector abs_velocities =
-                    get_latest_observation().velocity.cwiseAbs();
-
-                uint32_t running_index = step_count % SIZE_VELOCITY_WINDOW;
-                if (step_count >= SIZE_VELOCITY_WINDOW)
-                {
-                    summed_velocities -= running_velocities[running_index];
-                }
-                running_velocities[running_index] = abs_velocities;
-                summed_velocities += abs_velocities;
-                step_count++;
-
-#ifdef VERBOSE
-                Eigen::IOFormat commainitfmt(
-                    4, Eigen::DontAlignCols, " ", " ", "", "", "", "");
-                std::cout << ((summed_velocities / SIZE_VELOCITY_WINDOW)
-                                  .array() > STOP_VELOCITY)
-                                 .format(commainitfmt)
-                          << std::endl;
-#endif
-            }
-            rt_printf("Reached end stop.\n");
-        }
-
-        // Home on encoder index
-        HomingReturnCode homing_status = joint_modules_.execute_homing(
-            SEARCH_DISTANCE_LIMIT_RAD, home_offset_rad);
-
-        rt_printf("Finished homing.\n");
-
-        return homing_status == HomingReturnCode::SUCCEEDED;
-    }
+        Vector home_offset_rad = Vector::Zero());
 
     /**
      * @brief Move to given goal position using PD control.
@@ -627,83 +216,108 @@ protected:
      */
     bool move_to_position(const Vector &goal_pos,
                           const double tolerance,
-                          const uint32_t timeout_cycles)
-    {
-        bool reached_goal = false;
-        uint32_t cycle_count = 0;
+                          const uint32_t timeout_cycles);
+};
 
-        while (!reached_goal && cycle_count < timeout_cycles)
-        {
-            apply_action(Action::Position(goal_pos));
+/**
+ * @brief Configuration of the robot that can be changed by the user.
+ */
+template <size_t N_JOINTS, size_t N_MOTOR_BOARDS>
+struct NJointBlmcRobotDriver<N_JOINTS, N_MOTOR_BOARDS>::Config
+{
+    typedef std::array<std::string, N_MOTOR_BOARDS> CanPortArray;
 
-            const Vector position_error =
-                goal_pos - get_latest_observation().position;
-            const Vector velocity = get_latest_observation().velocity;
-
-            // Check if the goal is reached (position error below tolerance and
-            // velocity close to zero).
-            constexpr double ZERO_VELOCITY = 1e-4;
-            reached_goal = ((position_error.array().abs() < tolerance).all() &&
-                            (velocity.array().abs() < ZERO_VELOCITY).all());
-
-            cycle_count++;
-        }
-
-        return reached_goal;
-    }
-
-protected:
-    BlmcJointModules<N_JOINTS> joint_modules_;
-    MotorBoards motor_boards_;
-
-    //! \brief Fixed motor parameters (assuming all joints use same setup).
-    MotorParameters motor_parameters_;
-
-    //! \brief Maximum torque allowed on each joint.
-    double max_torque_Nm_;
+    // All parameters should have default values that should not result in
+    // dangerous behaviour in case someone forgets to specify them.
 
     /**
-     * \brief User-defined configuration of the driver
+     * @brief List of CAN port names used by the robot.
      *
-     * Contains all configuration values that can be modified by the user (via
-     * the configuration file).
+     * For each motor control board used by the robot, this specifies the
+     * CAN port through which it is connected.
+     *
+     * Example: `{"can0", "can1"}`
      */
-    Config config_;
+    CanPortArray can_ports;
 
-    bool is_initialized_ = false;
+    //! @brief Maximum current that can be sent to the motor [A].
+    double max_current_A = 0.0;
 
-    //! \brief Actual initialization that is called in a real-time thread in
-    //!        initialize().
-    void _initialize()
+    /**
+     * @brief Whether the joints have physical end stops or not.
+     *
+     * This is for example relevant for homing, where (in case this value
+     * is set to true) all joints move until they hit the end stop to
+     * determine their absolute position.
+     *
+     * Note that not having end stops does not mean that the joint can
+     * rotate freely in general.
+     */
+    bool has_endstop = false;
+
+    //! @brief Parameters related to calibration.
+    CalibrationParameters calibration = {
+        .endstop_search_torque_Nm = 0.0,
+        .position_tolerance_rad = 0.0,
+        .move_timeout = 0,
+    };
+
+    //! \brief D-gain to dampen velocity.  Set to zero to disable damping.
+    // set some rather high damping by default
+    Vector safety_kd = Vector::Constant(0.1);
+
+    //! @brief Default control gains for the position PD controller.
+    struct
     {
-        joint_modules_.set_position_control_gains(
-            config_.position_control_gains.kp,
-            config_.position_control_gains.kd);
+        Vector kp = Vector::Zero();
+        Vector kd = Vector::Zero();
+    } position_control_gains;
 
-        is_initialized_ = home_on_index_after_negative_end_stop(
-            config_.calibration.endstop_search_torque_Nm,
-            config_.home_offset_rad);
+    //! \brief Offset between home position and zero.
+    Vector home_offset_rad = Vector::Zero();
 
-        if (is_initialized_)
-        {
-            bool reached_goal =
-                move_to_position(config_.initial_position_rad,
-                                 config_.calibration.position_tolerance_rad,
-                                 config_.calibration.move_timeout);
-            if (!reached_goal)
-            {
-                rt_printf("Failed to reach goal, timeout exceeded.\n");
-            }
-        }
+    /**
+     * @brief Initial position to which the robot moves after
+     *        initialization.
+     */
+    Vector initial_position_rad = Vector::Zero();
 
-        pause_motors();
-    }
+    /**
+     * @brief Print the given configuration in a human-readable way.
+     */
+    void print() const;
 
-public:
-    Vector get_max_torques() const
-    {
-        return max_torque_Nm_ * Vector::Ones();
-    }
+    /**
+     * @brief Load driver configuration from file.
+     *
+     * Load the configuration from the specified YAML file.  The file is
+     * expected to have the same structure/key naming as the Config struct.
+     * If a value can not be read from the file, the application exists
+     * with an error message.
+     *
+     * @param config_file_name  Path/name of the configuration YAML file.
+     *
+     * @return Configuration
+     */
+    static Config load_config(const std::string &config_file_name);
+
+private:
+    /**
+     * \brief Set value from user configuration to var if specified.
+     *
+     * Checks if a field `name` exists in `user_config`.  If yes, its value
+     * is written to `var`, otherwise `var` is unchanged.
+     *
+     * \param[in] user_config  YAML node containing the user configuration.
+     * \param[in] name  Name of the configuration entry.
+     * \param[out] var  Variable to which configuration is written.  Value
+     * is unchanged if the specified field name does not exist in
+     * user_config, i.e.  it can be initialized with a default value.
+     */
+    template <typename T>
+    static void set_config_value(const YAML::Node &user_config,
+                                 const std::string &name,
+                                 T *var);
 };
 
 template <typename Driver>
@@ -734,3 +348,5 @@ typename Driver::Types::BackendPtr create_backend(
 }
 
 }  // namespace blmc_robots
+
+#include "n_joint_blmc_robot_driver.hxx"

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -1,0 +1,440 @@
+/**
+ * \file
+ * \brief Base driver for a generic n-joint BLMC robot.
+ * \copyright Copyright (c) 2019, New York University and Max Planck
+ *            Gesellschaft.
+ */
+
+#include <cstddef>
+#include <string>
+
+#define TPL_NJBRD template <size_t N_JOINTS, size_t N_MOTOR_BOARDS>
+#define NJBRD NJointBlmcRobotDriver<N_JOINTS, N_MOTOR_BOARDS>
+
+namespace blmc_robots
+{
+TPL_NJBRD
+void NJBRD::Config::print() const
+{
+    std::cout << "Configuration:\n"
+              << "\t can_ports:";
+    for (const auto &port : can_ports)
+    {
+        std::cout << " " << port;
+    }
+    std::cout << "\n"
+              << "\t max_current_A: " << max_current_A << "\n"
+              << "\t has_endstop: " << has_endstop << "\n"
+              << "\t calibration: "
+              << "\n"
+              << "\t\t endstop_search_torque_Nm: "
+              << calibration.endstop_search_torque_Nm << "\n"
+              << "\t\t position_tolerance_rad: "
+              << calibration.position_tolerance_rad << "\n"
+              << "\t\t move_timeout: " << calibration.move_timeout << "\n"
+              << "\t safety_kd: " << safety_kd.transpose() << "\n"
+              << "\t position_control_gains: "
+              << "\n"
+              << "\t\t kp: " << position_control_gains.kp.transpose() << "\n"
+              << "\t\t kd: " << position_control_gains.kd.transpose() << "\n"
+              << "\t home_offset_rad: " << home_offset_rad.transpose() << "\n"
+              << "\t initial_position_rad: " << initial_position_rad.transpose()
+              << "\n"
+              << std::endl;
+}
+
+TPL_NJBRD
+typename NJBRD::Config NJBRD::Config::load_config(
+    const std::string &config_file_name)
+{
+    NJBRD::Config config;
+    YAML::Node user_config;
+
+    try
+    {
+        user_config = YAML::LoadFile(config_file_name);
+    }
+    catch (...)
+    {
+        std::cout << "FATAL: Failed to load configuration from '"
+                  << config_file_name << "'." << std::endl;
+        std::exit(1);
+    }
+
+    // replace values from the default config with the ones given in the
+    // users config file
+
+    // TODO: for some reason direct conversion is not working (despite
+    // yaml-cpp implementing a generic conversion for std::array)
+    // set_config_value<CanPortArray>(user_config, "can_ports",
+    // &config.can_ports);
+    try
+    {
+        for (size_t i = 0; i < config.can_ports.size(); i++)
+        {
+            config.can_ports[i] = user_config["can_ports"][i].as<std::string>();
+        }
+    }
+    catch (...)
+    {
+        std::cerr << "FATAL: Failed to load parameter 'can_ports' from "
+                     "configuration file"
+                  << std::endl;
+        std::exit(1);
+    }
+
+    set_config_value(user_config, "max_current_A", &config.max_current_A);
+    set_config_value(user_config, "has_endstop", &config.has_endstop);
+
+    if (user_config["calibration"])
+    {
+        YAML::Node calib = user_config["calibration"];
+
+        set_config_value(calib,
+                         "endstop_search_torque_Nm",
+                         &config.calibration.endstop_search_torque_Nm);
+        set_config_value(calib,
+                         "position_tolerance_rad",
+                         &config.calibration.position_tolerance_rad);
+        set_config_value(
+            calib, "move_timeout", &config.calibration.move_timeout);
+    }
+
+    set_config_value(user_config, "safety_kd", &config.safety_kd);
+
+    if (user_config["position_control_gains"])
+    {
+        YAML::Node pos_ctrl = user_config["position_control_gains"];
+
+        set_config_value(pos_ctrl, "kp", &config.position_control_gains.kp);
+        set_config_value(pos_ctrl, "kd", &config.position_control_gains.kd);
+    }
+
+    set_config_value(user_config, "home_offset_rad", &config.home_offset_rad);
+    set_config_value(
+        user_config, "initial_position_rad", &config.initial_position_rad);
+
+    return config;
+}
+
+TPL_NJBRD
+template <typename T>
+void NJBRD::Config::set_config_value(const YAML::Node &user_config,
+                                     const std::string &name,
+                                     T *var)
+{
+    try
+    {
+        *var = user_config[name].as<T>();
+    }
+    catch (const YAML::Exception &e)
+    {
+        std::cerr << "FATAL: Failed to load parameter '" << name
+                  << "' from configuration file" << std::endl;
+        std::exit(1);
+    };
+}
+
+TPL_NJBRD
+typename NJBRD::MotorBoards NJBRD::create_motor_boards(
+    const std::array<std::string, N_MOTOR_BOARDS> &can_ports)
+{
+    // setup can buses -----------------------------------------------------
+    std::array<std::shared_ptr<blmc_drivers::CanBus>, N_MOTOR_BOARDS> can_buses;
+    for (size_t i = 0; i < can_buses.size(); i++)
+    {
+        can_buses[i] = std::make_shared<blmc_drivers::CanBus>(can_ports[i]);
+    }
+
+    // set up motor boards -------------------------------------------------
+    MotorBoards motor_boards;
+    for (size_t i = 0; i < motor_boards.size(); i++)
+    {
+        motor_boards[i] = std::make_shared<blmc_drivers::CanBusMotorBoard>(
+            can_buses[i], 1000, 10);
+        /// \TODO: reduce the timeout further!!
+    }
+
+    for (size_t i = 0; i < motor_boards.size(); i++)
+    {
+        motor_boards[i]->wait_until_ready();
+    }
+
+    return motor_boards;
+}
+
+TPL_NJBRD
+void NJBRD::pause_motors()
+{
+    for (size_t i = 0; i < motor_boards_.size(); i++)
+    {
+        motor_boards_[i]->pause_motors();
+    }
+}
+
+TPL_NJBRD
+typename NJBRD::Vector NJBRD::get_measured_index_angles() const
+{
+    return joint_modules_.get_measured_index_angles();
+}
+
+TPL_NJBRD
+void NJBRD::initialize()
+{
+    // Initialization is moving the robot and thus needs to be executed in
+    // a real-time thread.  This method only starts the thread and waits
+    // for it to finish.  Actual implementation of initialization is in
+    // `_initialize()`.
+
+    real_time_tools::RealTimeThread realtime_thread;
+    realtime_thread.create_realtime_thread(
+        [](void *instance_pointer) {
+            // instance_pointer = this, cast to correct type and call the
+            // _initialize() method.
+            ((NJointBlmcRobotDriver<N_JOINTS, N_MOTOR_BOARDS>
+                  *)(instance_pointer))
+                ->_initialize();
+            return (void *)nullptr;
+        },
+        this);
+    realtime_thread.join();
+}
+
+TPL_NJBRD
+typename NJBRD::Observation NJBRD::get_latest_observation()
+{
+    Observation observation;
+    observation.position = joint_modules_.get_measured_angles();
+    observation.velocity = joint_modules_.get_measured_velocities();
+    observation.torque = joint_modules_.get_measured_torques();
+    return observation;
+}
+
+TPL_NJBRD
+typename NJBRD::Action NJBRD::apply_action(const NJBRD::Action &desired_action)
+{
+    if (!is_initialized_)
+    {
+        throw std::runtime_error(
+            "Robot needs to be initialized before applying actions.  Run "
+            "the `initialize()` method.");
+    }
+
+    return apply_action_uninitialized(desired_action);
+}
+
+TPL_NJBRD
+std::string NJBRD::get_error()
+{
+    // Checks each board for errors and translates the error codes into
+    // human-readable strings.  If multiple boards have errors, the messages
+    // are concatenated.  Each message is prepended with the index of the
+    // corresponding board.
+
+    std::string error_msg = "";
+
+    for (size_t i = 0; i < motor_boards_.size(); i++)
+    {
+        auto status_timeseries = motor_boards_[i]->get_status();
+        if (status_timeseries->length() > 0)
+        {
+            std::string board_error_msg = "";
+            using ErrorCodes = blmc_drivers::MotorBoardStatus::ErrorCodes;
+            switch (status_timeseries->newest_element().error_code)
+            {
+                case ErrorCodes::NONE:
+                    break;
+                case ErrorCodes::ENCODER:
+                    board_error_msg = "Encoder Error";
+                    break;
+                case ErrorCodes::CAN_RECV_TIMEOUT:
+                    board_error_msg = "CAN Receive Timeout";
+                    break;
+                case ErrorCodes::CRIT_TEMP:
+                    board_error_msg = "Critical Temperature";
+                    break;
+                case ErrorCodes::POSCONV:
+                    board_error_msg =
+                        "Error in SpinTAC Position Convert module";
+                    break;
+                case ErrorCodes::POS_ROLLOVER:
+                    board_error_msg = "Position Rollover";
+                    break;
+                case ErrorCodes::OTHER:
+                    board_error_msg = "Other Error";
+                    break;
+                default:
+                    board_error_msg = "Unknown Error";
+                    break;
+            }
+
+            if (!board_error_msg.empty())
+            {
+                if (!error_msg.empty())
+                {
+                    error_msg += "  ";
+                }
+
+                // error of the board with board index to the error message
+                // string
+                error_msg +=
+                    "[Board " + std::to_string(i) + "] " + board_error_msg;
+            }
+        }
+    }
+
+    return error_msg;
+}
+
+TPL_NJBRD
+void NJBRD::shutdown()
+{
+    pause_motors();
+}
+
+TPL_NJBRD
+typename NJBRD::Action NJBRD::apply_action_uninitialized(
+    const NJBRD::Action &desired_action)
+{
+    double start_time_sec = real_time_tools::Timer::get_current_time_sec();
+
+    Observation observation = get_latest_observation();
+
+    Action applied_action = robot_interfaces::NJointRobotFunctions<
+        N_JOINTS>::process_desired_action(desired_action,
+                                          observation,
+                                          max_torque_Nm_,
+                                          config_.safety_kd,
+                                          config_.position_control_gains.kp,
+                                          config_.position_control_gains.kd);
+
+    joint_modules_.set_torques(applied_action.torque);
+    joint_modules_.send_torques();
+
+    real_time_tools::Timer::sleep_until_sec(start_time_sec + 0.001);
+
+    return applied_action;
+}
+
+TPL_NJBRD
+void NJBRD::_initialize()
+{
+    joint_modules_.set_position_control_gains(
+        config_.position_control_gains.kp, config_.position_control_gains.kd);
+
+    is_initialized_ = home_on_index_after_negative_end_stop(
+        config_.calibration.endstop_search_torque_Nm, config_.home_offset_rad);
+
+    if (is_initialized_)
+    {
+        bool reached_goal =
+            move_to_position(config_.initial_position_rad,
+                             config_.calibration.position_tolerance_rad,
+                             config_.calibration.move_timeout);
+        if (!reached_goal)
+        {
+            rt_printf("Failed to reach goal, timeout exceeded.\n");
+        }
+    }
+
+    pause_motors();
+}
+
+TPL_NJBRD
+bool NJBRD::home_on_index_after_negative_end_stop(
+    double endstop_search_torque_Nm, NJBRD::Vector home_offset_rad)
+{
+    //! Distance after which encoder index search is aborted.
+    //! Computed based on gear ratio to be 1.5 motor revolutions.
+    const double SEARCH_DISTANCE_LIMIT_RAD =
+        (1.5 / motor_parameters_.gear_ratio) * 2 * M_PI;
+
+    rt_printf("Start homing.\n");
+    if (has_endstop_)
+    {
+        //! Min. number of steps when moving to the end stop.
+        constexpr uint32_t MIN_STEPS_MOVE_TO_END_STOP = 1000;
+        //! Size of the window when computing average velocity.
+        constexpr uint32_t SIZE_VELOCITY_WINDOW = 100;
+        //! Velocity limit at which the joints are considered to be stopped
+        constexpr double STOP_VELOCITY = 0.01;
+
+        static_assert(MIN_STEPS_MOVE_TO_END_STOP > SIZE_VELOCITY_WINDOW,
+                      "MIN_STEPS_MOVE_TO_END_STOP has to be bigger than"
+                      " SIZE_VELOCITY_WINDOW to ensure correct computation"
+                      " of average velocity.");
+
+        // Move until velocity drops to almost zero (= joints hit the end
+        // stops) but at least for MIN_STEPS_MOVE_TO_END_STOP time steps.
+        // TODO: add timeout to this loop?
+        std::vector<Vector> running_velocities(SIZE_VELOCITY_WINDOW);
+        Vector summed_velocities = Vector::Zero();
+        uint32_t step_count = 0;
+        while (step_count < MIN_STEPS_MOVE_TO_END_STOP ||
+               (summed_velocities.maxCoeff() / SIZE_VELOCITY_WINDOW >
+                STOP_VELOCITY))
+        {
+            Vector torques = Vector::Constant(-endstop_search_torque_Nm);
+            apply_action_uninitialized(torques);
+            Vector abs_velocities =
+                get_latest_observation().velocity.cwiseAbs();
+
+            uint32_t running_index = step_count % SIZE_VELOCITY_WINDOW;
+            if (step_count >= SIZE_VELOCITY_WINDOW)
+            {
+                summed_velocities -= running_velocities[running_index];
+            }
+            running_velocities[running_index] = abs_velocities;
+            summed_velocities += abs_velocities;
+            step_count++;
+
+#ifdef VERBOSE
+            Eigen::IOFormat commainitfmt(
+                4, Eigen::DontAlignCols, " ", " ", "", "", "", "");
+            std::cout << ((summed_velocities / SIZE_VELOCITY_WINDOW).array() >
+                          STOP_VELOCITY)
+                             .format(commainitfmt)
+                      << std::endl;
+#endif
+        }
+        rt_printf("Reached end stop.\n");
+    }
+
+    // Home on encoder index
+    HomingReturnCode homing_status = joint_modules_.execute_homing(
+        SEARCH_DISTANCE_LIMIT_RAD, home_offset_rad);
+
+    rt_printf("Finished homing.\n");
+
+    return homing_status == HomingReturnCode::SUCCEEDED;
+}
+
+TPL_NJBRD
+bool NJBRD::move_to_position(const NJBRD::Vector &goal_pos,
+                             const double tolerance,
+                             const uint32_t timeout_cycles)
+{
+    bool reached_goal = false;
+    uint32_t cycle_count = 0;
+
+    while (!reached_goal && cycle_count < timeout_cycles)
+    {
+        apply_action(Action::Position(goal_pos));
+
+        const Vector position_error =
+            goal_pos - get_latest_observation().position;
+        const Vector velocity = get_latest_observation().velocity;
+
+        // Check if the goal is reached (position error below tolerance and
+        // velocity close to zero).
+        constexpr double ZERO_VELOCITY = 1e-4;
+        reached_goal = ((position_error.array().abs() < tolerance).all() &&
+                        (velocity.array().abs() < ZERO_VELOCITY).all());
+
+        cycle_count++;
+    }
+
+    return reached_goal;
+}
+
+}  // namespace blmc_robots

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -5,9 +5,6 @@
  *            Gesellschaft.
  */
 
-#include <cstddef>
-#include <string>
-
 #define TPL_NJBRD template <size_t N_JOINTS, size_t N_MOTOR_BOARDS>
 #define NJBRD NJointBlmcRobotDriver<N_JOINTS, N_MOTOR_BOARDS>
 


### PR DESCRIPTION
## Description

Move the implementation of all the methods to a separate hxx file.
Also move the definition of the `Config` struct below the class
definition, keeping only a forward declaration in the latter.

These changes have the purpose of making the definition of the driver
class more readable (e.g. make it more easy to see if a method is
public or protected).

## How I Tested

Not really as I don't have access to the robot at the moment.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
