### PR TITLE
Add first_action_timeout option to create_backend

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -320,10 +320,24 @@ private:
                                  T *var);
 };
 
+/**
+ * @brief Create backend using the specified driver.
+ *
+ * @tparam Driver  Type of the driver.  Expected to inherit from
+ *     NJointBlmcRobotDriver.
+ *
+ * @param robot_data  Instance of RobotData used for communication.
+ * @param config_file_path  Path to the driver configuration file.
+ * @param first_action_timeout  Duration for which the backend waits for the
+ *     first action to arrive.  If exceeded, the backend shuts down.
+ *
+ * @return A RobotBackend instances with a driver of the specified type.
+ */
 template <typename Driver>
 typename Driver::Types::BackendPtr create_backend(
     typename Driver::Types::BaseDataPtr robot_data,
-    const std::string &config_file_path)
+    const std::string &config_file_path,
+    const double first_action_timeout = std::numeric_limits<double>::infinity())
 {
     constexpr double MAX_ACTION_DURATION_S = 0.003;
     constexpr double MAX_INTER_ACTION_DURATION_S = 0.005;
@@ -340,8 +354,9 @@ typename Driver::Types::BackendPtr create_backend(
             MAX_ACTION_DURATION_S,
             MAX_INTER_ACTION_DURATION_S);
 
+    constexpr bool real_time_mode = true;
     auto backend = std::make_shared<typename Driver::Types::Backend>(
-        monitored_driver, robot_data);
+        monitored_driver, robot_data, real_time_mode, first_action_timeout);
     backend->set_max_action_repetitions(std::numeric_limits<uint32_t>::max());
 
     return backend;


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Add first_action_timeout option to create_backend


## How I Tested
Compiled but not tested on the robot due to home office.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
