### PR TITLE
Add missing include in demos

### DIFF
--- a/demos/demo_solo12.cpp
+++ b/demos/demo_solo12.cpp
@@ -7,7 +7,7 @@
  * This file uses the Solo12 class in a small demo.
  */
 
-
+#include <numeric>
 #include "blmc_robots/solo12.hpp"
 #include "blmc_robots/common_programs_header.hpp"
 

--- a/demos/demo_solo8.cpp
+++ b/demos/demo_solo8.cpp
@@ -7,7 +7,7 @@
  * This file uses the Solo8 class in a small demo.
  */
 
-
+#include <numeric>
 #include "blmc_robots/solo8.hpp"
 #include "blmc_robots/common_programs_header.hpp"
 

--- a/demos/demo_solo8ti.cpp
+++ b/demos/demo_solo8ti.cpp
@@ -7,7 +7,7 @@
  * This file uses the Solo8TI class in a small demo.
  */
 
-
+#include <numeric>
 #include "blmc_robots/solo8ti.hpp"
 #include "blmc_robots/common_programs_header.hpp"
 

--- a/demos/demo_teststand.cpp
+++ b/demos/demo_teststand.cpp
@@ -7,7 +7,7 @@
  * This file uses the Teststand class in a small demo.
  */
 
-
+#include <numeric>
 #include "blmc_robots/teststand.hpp"
 #include "blmc_robots/common_programs_header.hpp"
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Add missing include of `numeric` in demos (needed for `std::accumulate`).  This caused a build issue when building on Ubuntu 18.04 (interestingly it was not a problem with 16.04).


## How I Tested

By building it.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
