### PR TITLE
Homing: Use separate torque/step size for each joint

### DIFF
--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -611,13 +611,13 @@ public:
      */
     HomingReturnCode execute_homing(double search_distance_limit_rad,
             Vector home_offset_rad,
-            double profile_step_size_rad=0.001)
+            Vector profile_step_size_rad=Vector::Constant(0.001))
     {
         // Initialise homing for all joints
         for(size_t i = 0; i < COUNT; i++)
         {
             modules_[i]->init_homing((int) i, search_distance_limit_rad,
-                    home_offset_rad[i], profile_step_size_rad);
+                    home_offset_rad[i], profile_step_size_rad[i]);
         }
 
         // run homing for all joints until all of them are done

--- a/include/blmc_robots/blmc_joint_module.hpp
+++ b/include/blmc_robots/blmc_joint_module.hpp
@@ -3,16 +3,17 @@
  * @author Manuel Wuthrich
  * @author Maximilien Naveau (maximilien.naveau@gmail.com)
  * @license License BSD-3-Clause
- * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ *            Gesellschaft.
  * @date 2019-07-11
  */
 #pragma once
 
-#include <iostream>
-#include <array>
-#include <stdexcept>
 #include <math.h>
 #include <Eigen/Eigen>
+#include <array>
+#include <iostream>
+#include <stdexcept>
 
 #include "blmc_drivers/devices/motor.hpp"
 #include "blmc_robots/common_header.hpp"
@@ -20,13 +21,13 @@
 
 namespace blmc_robots
 {
-
 // TODO what is the best scope for those homing-related types?
 
 /**
  * @brief Possible return values of the homing
  */
-enum class HomingReturnCode {
+enum class HomingReturnCode
+{
     //! Homing was not initialized and can therefore not be performed.
     NOT_INITIALIZED = 0,
     //! Homing is currently running.
@@ -40,7 +41,8 @@ enum class HomingReturnCode {
 /**
  * @brief Possible return values of the go_to
  */
-enum class GoToReturnCode {
+enum class GoToReturnCode
+{
     //! GoTo is currently running.
     RUNNING,
     //! Position has been reached succeeded.
@@ -49,11 +51,11 @@ enum class GoToReturnCode {
     FAILED
 };
 
-
 /**
  * @brief State variables required for the homing.
  */
-struct HomingState {
+struct HomingState
+{
     //! Id of the joint.  Just use for debug prints.
     int joint_id = 0;
     //! Max. distance to move while searching the encoder index.
@@ -72,8 +74,6 @@ struct HomingState {
     HomingReturnCode status = HomingReturnCode::NOT_INITIALIZED;
 };
 
-
-
 /**
  * @brief The BlmcJointModule class is containing the joint information. It is
  * here to help converting the data from the motor side to the joint side. It
@@ -82,30 +82,29 @@ struct HomingState {
 class BlmcJointModule
 {
 public:
-
     /**
      * @brief Construct a new BlmcJointModule object
-     * 
+     *
      * @param motor is the C++ object allowing us to send commands and receive
      * sensor data.
-     * @param motor_constant (\f$ k \f$) is the torque constant of the motor 
+     * @param motor_constant (\f$ k \f$) is the torque constant of the motor
      * \f$ \tau_{motor} = k * i_{motor} \f$
      * @param gear_ratio is the gear ratio between the motor and the joint.
      * @param zero_angle is the angle between the closest positive motor index
      * and the zero configuration.
-     * @param reverse_polarity 
-     * @param max_current 
+     * @param reverse_polarity
+     * @param max_current
      */
     BlmcJointModule(std::shared_ptr<blmc_drivers::MotorInterface> motor,
                     const double& motor_constant,
                     const double& gear_ratio,
                     const double& zero_angle,
-                    const bool& reverse_polarity=false,
-                    const double& max_current=2.1);
+                    const bool& reverse_polarity = false,
+                    const double& max_current = 2.1);
 
     /**
      * @brief Set the joint torque to be sent.
-     * 
+     *
      * @param desired_torque (Nm)
      */
     void set_torque(const double& desired_torque);
@@ -113,14 +112,14 @@ public:
     /**
      * @brief Set the zero_angle. The zero_angle is the angle between the
      * closest positive motor index and the zero configuration.
-     * 
+     *
      * @param zero_angle (rad)
      */
     void set_zero_angle(const double& zero_angle);
 
     /**
      * @brief Define if the motor should turn clock-wize or counter clock-wize.
-     * 
+     *
      * @param reverse_polarity true:reverse rotation axis, false:do nothing.
      */
     void set_joint_polarity(const bool& reverse_polarity);
@@ -133,28 +132,28 @@ public:
 
     /**
      * @brief Get the maximum admissible joint torque that can be applied.
-     * 
-     * @return double 
+     *
+     * @return double
      */
     double get_max_torque() const;
 
     /**
      * @brief Get the sent joint torque.
-     * 
+     *
      * @return double (Nm).
      */
     double get_sent_torque() const;
 
     /**
      * @brief Get the measured joint torque.
-     * 
+     *
      * @return double (Nm).
      */
     double get_measured_torque() const;
 
     /**
      * @brief Get the measured angle of the joint.
-     * 
+     *
      * @return double (rad).
      */
     double get_measured_angle() const;
@@ -162,15 +161,15 @@ public:
     /**
      * @brief Get the measured velocity of the joint. This data is computed on
      * board of the control card.
-     * 
+     *
      * @return double (rad/s).
      */
     double get_measured_velocity() const;
 
     /**
-     * @brief Get the measured index angle. There is one index per motor rotation so
-     * there are gear_ratio indexes per joint rotation.
-     * 
+     * @brief Get the measured index angle. There is one index per motor
+     * rotation so there are gear_ratio indexes per joint rotation.
+     *
      * @return double (rad).
      */
     double get_measured_index_angle() const;
@@ -178,7 +177,7 @@ public:
     /**
      * @brief Get the zero_angle_. These are the angle between the starting pose
      * and the theoretical zero pose.
-     * 
+     *
      * @return double (rad).
      */
     double get_zero_angle() const;
@@ -205,9 +204,9 @@ public:
      * @brief This method calibrate the joint position knowing the angle between
      * the closest (in positive torque) motor index and the theoretical zero
      * pose. Warning, this method should be called in a real time thread!
-     * 
+     *
      * @param[in][out] angle_zero_to_index (rad) this is the angle between the
-     * closest (in positive torque) motor index and the theoretical zero pose. 
+     * closest (in positive torque) motor index and the theoretical zero pose.
      * @param[out] index_angle (rad) is the angle where we met the index. This
      * angle is relative to the configuration when the robot booted.
      * @param[in] mechanical_calibration defines if the leg started in the zero
@@ -229,13 +228,15 @@ public:
      *     searching for the encoder index.  Unit: radian.
      * @param home_offset_rad  Offset from home position to zero position.
      *     Unit: radian.
-     * @param profile_step_size_rad  Distance by which the target position of the
-     *     position profile is changed in each step.  Set to a negative value to
+     * @param profile_step_size_rad  Distance by which the target position of
+     * the position profile is changed in each step.  Set to a negative value to
      *     search for the next encoder index in negative direction.  Unit:
      *     radian.
      */
-    void init_homing(int joint_id, double search_distance_limit_rad, double
-            home_offset_rad, double profile_step_size_rad=0.001);
+    void init_homing(int joint_id,
+                     double search_distance_limit_rad,
+                     double home_offset_rad,
+                     double profile_step_size_rad = 0.001);
 
     /**
      * @brief Perform one step of homing on encoder index.
@@ -264,7 +265,7 @@ public:
 private:
     /**
      * @brief Convert from joint torque to motor current.
-     * 
+     *
      * @param[in] torque is the input joint
      * @return double the equivalent motor current.
      */
@@ -272,7 +273,7 @@ private:
 
     /**
      * @brief Convert from motor current to joint torque.
-     * 
+     *
      * @param current is the motor current.
      * @return double is the equivalent joint torque.
      */
@@ -280,7 +281,7 @@ private:
 
     /**
      * @brief Get motor measurements and check if there are data or not.
-     * 
+     *
      * @param measurement_id is the id of the measurement you want to get.
      * check: blmc_drivers::MotorInterface::MeasurementIndex
      * @return double the measurement.
@@ -290,7 +291,7 @@ private:
     /**
      * @brief Get the last motor measurement index for a specific data. If there
      * was no data yet, return NaN
-     * 
+     *
      * @param measurement_id is the id of the measurement you want to get.
      * check: blmc_drivers::MotorInterface::MeasurementIndex
      * @return double the measurement.
@@ -308,8 +309,8 @@ private:
      */
     double motor_constant_;
     /**
-     * @brief This correspond to the reduction (\f$ \beta \f$) between the motor rotation and
-     * the joint. \f$ \theta_{joint} = \theta_{motor} / \beta \f$
+     * @brief This correspond to the reduction (\f$ \beta \f$) between the motor
+     * rotation and the joint. \f$ \theta_{joint} = \theta_{motor} / \beta \f$
      */
     double gear_ratio_;
     /**
@@ -336,15 +337,16 @@ private:
 };
 
 /**
- * @brief BlmcJointModule_ptr shortcut for the shared pointer BlmcJointModule type
+ * @brief BlmcJointModule_ptr shortcut for the shared pointer BlmcJointModule
+ * type
  */
 typedef std::shared_ptr<BlmcJointModule> BlmcJointModule_ptr;
 
 /**
  * @brief This class defines an interface to a collection of BLMC joints. It
  * creates a BLMCJointModule for every blmc_driver::MotorInterface provided.
- * 
- * @tparam COUNT 
+ *
+ * @tparam COUNT
  */
 template <int COUNT>
 class BlmcJointModules
@@ -358,21 +360,22 @@ public:
 
     /**
      * @brief Construct a new BlmcJointModules object.
-     * 
-     * @param motors 
-     * @param motor_constants 
-     * @param gear_ratios 
-     * @param zero_angles 
+     *
+     * @param motors
+     * @param motor_constants
+     * @param gear_ratios
+     * @param zero_angles
      */
     BlmcJointModules(
         const std::array<std::shared_ptr<blmc_drivers::MotorInterface>, COUNT>&
-          motors,
+            motors,
         const Vector& motor_constants,
         const Vector& gear_ratios,
         const Vector& zero_angles,
         const Vector& max_currents)
     {
-        set_motor_array(motors, motor_constants, gear_ratios, zero_angles, max_currents);
+        set_motor_array(
+            motors, motor_constants, gear_ratios, zero_angles, max_currents);
     }
     /**
      * @brief Construct a new BlmcJointModules object.
@@ -382,21 +385,21 @@ public:
     }
     /**
      * @brief Set the motor array, by creating the corresponding modules.
-     * 
-     * @param motors 
-     * @param motor_constants 
-     * @param gear_ratios 
-     * @param zero_angles 
+     *
+     * @param motors
+     * @param motor_constants
+     * @param gear_ratios
+     * @param zero_angles
      */
     void set_motor_array(
         const std::array<std::shared_ptr<blmc_drivers::MotorInterface>, COUNT>&
-          motors,
+            motors,
         const Vector& motor_constants,
         const Vector& gear_ratios,
         const Vector& zero_angles,
         const Vector& max_currents)
     {
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             modules_[i] = std::make_shared<BlmcJointModule>(motors[i],
                                                             motor_constants[i],
@@ -411,7 +414,7 @@ public:
      */
     void send_torques()
     {
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             modules_[i]->send_torque();
         }
@@ -420,24 +423,24 @@ public:
     /**
      * @brief Set the polarities of the joints
      * (see BlmcJointModule::set_joint_polarity)
-     * 
+     *
      * @param reverse_polarity
      */
     void set_joint_polarities(std::array<bool, COUNT> reverse_polarities)
     {
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             modules_[i]->set_joint_polarity(reverse_polarities[i]);
         }
     }
     /**
      * @brief Register the joint torques to be sent for all modules.
-     * 
+     *
      * @param desired_torques (Nm)
      */
     void set_torques(const Vector& desired_torques)
     {
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             modules_[i]->set_torque(desired_torques(i));
         }
@@ -445,13 +448,13 @@ public:
 
     /**
      * @brief Get the maximum admissible joint torque that can be applied.
-     * 
+     *
      * @return Vector (N/m)
      */
     Vector get_max_torques()
     {
         Vector max_torques;
-        for(size_t i = 0 ; i < COUNT ; ++i)
+        for (size_t i = 0; i < COUNT; ++i)
         {
             max_torques[i] = modules_[i]->get_max_torque();
         }
@@ -460,14 +463,14 @@ public:
 
     /**
      * @brief Get the previously sent torques.
-     * 
+     *
      * @return Vector (Nm)
      */
     Vector get_sent_torques() const
     {
         Vector torques;
 
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             torques(i) = modules_[i]->get_sent_torque();
         }
@@ -476,14 +479,14 @@ public:
 
     /**
      * @brief Get the measured joint torques.
-     * 
+     *
      * @return Vector (Nm)
      */
     Vector get_measured_torques() const
     {
         Vector torques;
 
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             torques(i) = modules_[i]->get_measured_torque();
         }
@@ -492,14 +495,14 @@ public:
 
     /**
      * @brief Get the measured joint angles.
-     * 
+     *
      * @return Vector (rad)
      */
     Vector get_measured_angles() const
     {
         Vector positions;
 
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             positions(i) = modules_[i]->get_measured_angle();
         }
@@ -508,14 +511,14 @@ public:
 
     /**
      * @brief Get the measured joint velocities.
-     * 
+     *
      * @return Vector (rad/s)
      */
     Vector get_measured_velocities() const
     {
         Vector velocities;
 
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             velocities(i) = modules_[i]->get_measured_velocity();
         }
@@ -525,12 +528,12 @@ public:
     /**
      * @brief Set the zero_angles. These are the joint angles between the
      * starting pose and the zero theoretical pose of the urdf.
-     * 
+     *
      * @param zero_angles (rad)
      */
     void set_zero_angles(const Vector& zero_angles)
     {
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             modules_[i]->set_zero_angle(zero_angles(i));
         }
@@ -538,14 +541,14 @@ public:
     /**
      * @brief Get the zero_angles. These are the joint angles between the
      * starting pose and the zero theoretical pose of the urdf.
-     * 
+     *
      * @return Vector (rad)
      */
     Vector get_zero_angles() const
     {
         Vector positions;
 
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             positions(i) = modules_[i]->get_zero_angle();
         }
@@ -554,14 +557,14 @@ public:
     /**
      * @brief Get the index_angles. There is one index per motor rotation so
      * there are gear_ratio indexes per joint rotation.
-     * 
+     *
      * @return Vector (rad)
      */
     Vector get_measured_index_angles() const
     {
         Vector index_angles;
 
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
             index_angles(i) = modules_[i]->get_measured_index_angle();
         }
@@ -588,9 +591,9 @@ public:
      */
     void set_position_control_gains(Vector kp, Vector kd)
     {
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
-           set_position_control_gains(i, kp[i], kd[i]);
+            set_position_control_gains(i, kp[i], kd[i]);
         }
     }
 
@@ -609,47 +612,53 @@ public:
      * @return Final status of the homing procedure (either SUCCESS if all
      *     joints succeeded or the return code of the first joint that failed).
      */
-    HomingReturnCode execute_homing(double search_distance_limit_rad,
-            Vector home_offset_rad,
-            Vector profile_step_size_rad=Vector::Constant(0.001))
+    HomingReturnCode execute_homing(
+        double search_distance_limit_rad,
+        Vector home_offset_rad,
+        Vector profile_step_size_rad = Vector::Constant(0.001))
     {
         // Initialise homing for all joints
-        for(size_t i = 0; i < COUNT; i++)
+        for (size_t i = 0; i < COUNT; i++)
         {
-            modules_[i]->init_homing((int) i, search_distance_limit_rad,
-                    home_offset_rad[i], profile_step_size_rad[i]);
+            modules_[i]->init_homing((int)i,
+                                     search_distance_limit_rad,
+                                     home_offset_rad[i],
+                                     profile_step_size_rad[i]);
         }
 
         // run homing for all joints until all of them are done
         real_time_tools::Spinner spinner;
         spinner.set_period(0.001);  // TODO magic number
         HomingReturnCode homing_status;
-        do {
+        do
+        {
             bool all_succeeded = true;
             homing_status = HomingReturnCode::RUNNING;
 
-            for(size_t i = 0; i < COUNT; i++)
+            for (size_t i = 0; i < COUNT; i++)
             {
                 HomingReturnCode joint_result = modules_[i]->update_homing();
 
                 all_succeeded &= (joint_result == HomingReturnCode::SUCCEEDED);
 
                 if (joint_result == HomingReturnCode::NOT_INITIALIZED ||
-                        joint_result == HomingReturnCode::FAILED) {
+                    joint_result == HomingReturnCode::FAILED)
+                {
                     homing_status = joint_result;
                     // abort homing
                     break;
                 }
             }
-            if(homing_status == HomingReturnCode::RUNNING)
+            if (homing_status == HomingReturnCode::RUNNING)
             {
-              for(unsigned i = 0 ; i < COUNT ; ++i)
-              {
-                  modules_[i]->send_torque();
-              }
+                for (unsigned i = 0; i < COUNT; ++i)
+                {
+                    modules_[i]->send_torque();
+                }
             }
 
-            if (all_succeeded) {
+            if (all_succeeded)
+            {
                 homing_status = HomingReturnCode::SUCCEEDED;
             }
 
@@ -662,69 +671,75 @@ public:
     /**
      * @brief Allow the robot to go to a desired pose. Once the control done
      * 0 torques is sent.
-     * 
+     *
      * @param angle_to_reach_rad (rad)
      * @param average_speed_rad_per_sec (rad/sec)
-     * @return GoToReturnCode 
+     * @return GoToReturnCode
      */
     GoToReturnCode go_to(Vector angle_to_reach_rad,
-                         double average_speed_rad_per_sec=1.0)
+                         double average_speed_rad_per_sec = 1.0)
     {
         // Compute a min jerk trajectory
         Vector initial_joint_positions = get_measured_angles();
         double final_time = (angle_to_reach_rad - initial_joint_positions)
-                            .array().abs().maxCoeff() /
+                                .array()
+                                .abs()
+                                .maxCoeff() /
                             average_speed_rad_per_sec;
 
-        std::array<TimePolynome<5> , COUNT> min_jerk_trajs;
-        for(unsigned i = 0; i < COUNT; i++)
+        std::array<TimePolynome<5>, COUNT> min_jerk_trajs;
+        for (unsigned i = 0; i < COUNT; i++)
         {
             min_jerk_trajs[i].set_parameters(final_time,
-              initial_joint_positions[i], 0.0 /*initial speed*/,
-              angle_to_reach_rad[i]);
+                                             initial_joint_positions[i],
+                                             0.0 /*initial speed*/,
+                                             angle_to_reach_rad[i]);
         }
 
         // run got_to for all joints
         real_time_tools::Spinner spinner;
-        double sampling_period = 0.001; // TODO magic number
-        spinner.set_period(sampling_period);  
+        double sampling_period = 0.001;  // TODO magic number
+        spinner.set_period(sampling_period);
         GoToReturnCode go_to_status;
         double current_time = 0.0;
-        do{
+        do
+        {
             // TODO: add a security if error gets too big
-            for(unsigned i = 0; i < COUNT; i++)
+            for (unsigned i = 0; i < COUNT; i++)
             {
                 double desired_pose = min_jerk_trajs[i].compute(current_time);
-                double desired_torque = 
+                double desired_torque =
                     modules_[i]->execute_position_controller(desired_pose);
                 modules_[i]->set_torque(desired_torque);
             }
-            for(unsigned i = 0 ; i < COUNT ; ++i)
+            for (unsigned i = 0; i < COUNT; ++i)
             {
                 modules_[i]->send_torque();
             }
             go_to_status = GoToReturnCode::RUNNING;
 
             current_time += sampling_period;
-            spinner.spin(); 
-                         
-        } while(current_time < (final_time + sampling_period));
+            spinner.spin();
+
+        } while (current_time < (final_time + sampling_period));
 
         // Stop all motors (0 torques) after the destination achieved
-        for(unsigned i = 0; i < COUNT; i++)
+        for (unsigned i = 0; i < COUNT; i++)
         {
             modules_[i]->set_torque(0.0);
         }
-        for(unsigned i = 0 ; i < COUNT ; ++i)
+        for (unsigned i = 0; i < COUNT; ++i)
         {
             modules_[i]->send_torque();
         }
 
         Vector final_pos = get_measured_angles();
-        if ( (angle_to_reach_rad - final_pos).isMuchSmallerThan(1.0, 1e-3) )
+        if ((angle_to_reach_rad - final_pos).isMuchSmallerThan(1.0, 1e-3))
         {
             go_to_status = GoToReturnCode::SUCCEEDED;
-        }else{
+        }
+        else
+        {
             go_to_status = GoToReturnCode::FAILED;
         }
         return go_to_status;
@@ -737,8 +752,4 @@ private:
     std::array<std::shared_ptr<BlmcJointModule>, COUNT> modules_;
 };
 
-
-
-
-
-} // namespace blmc_robots
+}  // namespace blmc_robots

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -45,19 +45,6 @@ struct MotorParameters
 };
 
 /**
- * @brief Parameters for the joint calibration (homing and go to initial pose).
- */
-struct CalibrationParameters
-{
-    //! @brief Torque that is used to find the end stop.
-    double endstop_search_torque_Nm;
-    //! @brief Tolerance for reaching the starting position.
-    double position_tolerance_rad;
-    //! @brief Timeout for reaching the starting position.
-    double move_timeout;
-};
-
-/**
  * @brief Base class for simple n-joint BLMC robots.
  *
  * This is a generic base class to easily implement drivers for simple BLMC
@@ -175,7 +162,7 @@ protected:
     void _initialize();
 
     /**
-     * @brief Homing on negative end stop and encoder index.
+     * @brief Homing using end stops (optional) and encoder indices.
      *
      * Procedure for finding an absolute zero position (or "home" position) when
      * using relative encoders.
@@ -194,13 +181,13 @@ protected:
      *     zero position = encoder index position + home offset
      *
      *
-     * @param endstop_search_torque_Nm Torque that is used to move the joints
+     * @param endstop_search_torques_Nm Torques that are used to move the joints
      *     while searching the end stop.
      * @param home_offset_rad Offset between the home position and the desired
      *     zero position.
      */
-    bool home_on_index_after_negative_end_stop(
-        double endstop_search_torque_Nm,
+    bool homing(
+        Vector endstop_search_torques_Nm,
         Vector home_offset_rad = Vector::Zero());
 
     /**
@@ -256,11 +243,15 @@ struct NJointBlmcRobotDriver<N_JOINTS, N_MOTOR_BOARDS>::Config
     bool has_endstop = false;
 
     //! @brief Parameters related to calibration.
-    CalibrationParameters calibration = {
-        .endstop_search_torque_Nm = 0.0,
-        .position_tolerance_rad = 0.0,
-        .move_timeout = 0,
-    };
+    struct
+    {
+        //! @brief Torque that is used to find the end stop.
+        Vector endstop_search_torques_Nm = Vector::Zero();
+        //! @brief Tolerance for reaching the starting position.
+        double position_tolerance_rad = 0.0;
+        //! @brief Timeout for reaching the starting position.
+        double move_timeout = 0.0;
+    } calibration;
 
     //! \brief D-gain to dampen velocity.  Set to zero to disable damping.
     // set some rather high damping by default
@@ -319,6 +310,7 @@ private:
                                  const std::string &name,
                                  T *var);
 };
+
 
 /**
  * @brief Create backend using the specified driver.

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -186,9 +186,8 @@ protected:
      * @param home_offset_rad Offset between the home position and the desired
      *     zero position.
      */
-    bool homing(
-        Vector endstop_search_torques_Nm,
-        Vector home_offset_rad = Vector::Zero());
+    bool homing(Vector endstop_search_torques_Nm,
+                Vector home_offset_rad = Vector::Zero());
 
     /**
      * @brief Move to given goal position using PD control.
@@ -310,7 +309,6 @@ private:
                                  const std::string &name,
                                  T *var);
 };
-
 
 /**
  * @brief Create backend using the specified driver.

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -319,8 +319,8 @@ void NJBRD::_initialize()
     joint_modules_.set_position_control_gains(
         config_.position_control_gains.kp, config_.position_control_gains.kd);
 
-    is_initialized_ = homing(
-        config_.calibration.endstop_search_torques_Nm, config_.home_offset_rad);
+    is_initialized_ = homing(config_.calibration.endstop_search_torques_Nm,
+                             config_.home_offset_rad);
 
     if (is_initialized_)
     {
@@ -338,8 +338,8 @@ void NJBRD::_initialize()
 }
 
 TPL_NJBRD
-bool NJBRD::homing(
-    NJBRD::Vector endstop_search_torques_Nm, NJBRD::Vector home_offset_rad)
+bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
+                   NJBRD::Vector home_offset_rad)
 {
     //! Distance after which encoder index search is aborted.
     //! Computed based on gear ratio to be 1.5 motor revolutions.
@@ -406,13 +406,16 @@ bool NJBRD::homing(
     for (unsigned int i = 0; i < N_JOINTS; i++)
     {
         index_search_step_sizes[i] = INDEX_SEARCH_STEP_SIZE_RAD;
-        if (endstop_search_torques_Nm[i] > 0) {
+        if (endstop_search_torques_Nm[i] > 0)
+        {
             index_search_step_sizes[i] *= -1;
         }
     }
 
-    HomingReturnCode homing_status = joint_modules_.execute_homing(
-        INDEX_SEARCH_DISTANCE_LIMIT_RAD, home_offset_rad, index_search_step_sizes);
+    HomingReturnCode homing_status =
+        joint_modules_.execute_homing(INDEX_SEARCH_DISTANCE_LIMIT_RAD,
+                                      home_offset_rad,
+                                      index_search_step_sizes);
 
     rt_printf("Finished homing.\n");
 

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -197,7 +197,7 @@ bool Solo12::calibrate(const Vector12d& home_offset_rad)
 {
   // Maximum distance is twice the angle between joint indexes
   double search_distance_limit_rad = 10.0 * (2.0 * M_PI / joint_gear_ratios_(0));
-  double profile_step_size_rad = 0.001;
+  Vector12d profile_step_size_rad = Vector12d::Constant(0.001);
   HomingReturnCode homing_return_code =
     joints_.execute_homing(search_distance_limit_rad, home_offset_rad,
                            profile_step_size_rad);

--- a/src/solo8ti.cpp
+++ b/src/solo8ti.cpp
@@ -237,7 +237,7 @@ bool Solo8TI::calibrate(const Vector8d& home_offset_rad)
 {
   // Maximum distance is twice the angle between joint indexes
   double search_distance_limit_rad = 2.0 * (2.0 * M_PI / 9.0);
-  double profile_step_size_rad=0.001;
+  Vector8d profile_step_size_rad = Vector8d::Constant(0.001);
   joints_.execute_homing(search_distance_limit_rad, home_offset_rad,
                          profile_step_size_rad);
   Vector8d zero_pose = Vector8d::Zero();

--- a/src/teststand.cpp
+++ b/src/teststand.cpp
@@ -186,7 +186,7 @@ bool Teststand::calibrate(const Vector2d& home_offset_rad)
 {
   // Maximum distance is twice the angle between joint indexes
   double search_distance_limit_rad = 2.0 * (2.0 * M_PI / 9.0);
-  double profile_step_size_rad=0.001;
+  Vector2d profile_step_size_rad = Vector2d::Constant(0.001);
   joints_.execute_homing(search_distance_limit_rad, home_offset_rad,
                          profile_step_size_rad);
   Vector2d zero_pose = Vector2d::Zero();


### PR DESCRIPTION
## Description
Instead of having scalar values for end-stop search torque and index search step size use Vectors with one value per joint.
This will be needed for our new robot where the kinematics are a bit different such that the joints need to move in different directions during the homing.

Note that the diff is quite big due to reformatting in the last commit, so it's probably better to review commit-wise.

## How I Tested

So far only ensured it builds with the BLMC_EI project.  @MaximilienNaveau, @vincentberenz are there other projects that would be affected by this change?

I will test on the Finger robots next time I go to the lab.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
