### PR TITLE
Determine travelled distance at end of homing

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -417,11 +417,11 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                                       home_offset_rad,
                                       index_search_step_sizes);
 
-    rt_printf("Finished homing.  Travelled distance: ");
+    rt_printf("Finished homing.  Offset: ");
     Vector travelled_distance = joint_modules_.get_distance_travelled_during_homing();
     for (size_t i = 0; i < N_JOINTS; i++)
     {
-        rt_printf("%.3f, ", travelled_distance[i]);
+        rt_printf("%.3f, ", -travelled_distance[i]);
     }
     rt_printf("\n");
 

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -417,7 +417,13 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                                       home_offset_rad,
                                       index_search_step_sizes);
 
-    rt_printf("Finished homing.\n");
+    rt_printf("Finished homing.  Travelled distance: ");
+    Vector travelled_distance = joint_modules_.get_distance_travelled_during_homing();
+    for (size_t i = 0; i < N_JOINTS; i++)
+    {
+        rt_printf("%.3f, ", travelled_distance[i]);
+    }
+    rt_printf("\n");
 
     return homing_status == HomingReturnCode::SUCCEEDED;
 }


### PR DESCRIPTION
## Description

Determine the travelled distance between start and end position of the homing procedure.

Print the negated value at the end of homing in NJointBlmcRobotDriver. When the joints are moved to the desired zero position before starting homing, this corresponds to the home offset.  As the "travelled distance" it is independent of the configured home offset, this allows to get a corrected home offset more easily without the need to first modify the config file.


## How I Tested

With FingerEdu.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
