### PR TITLE
Allow different observation types in NJointBlmcRobotDriver

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -44,7 +44,7 @@ struct MotorParameters
 };
 
 /**
- * @brief Base class for simple n-joint BLMC robots.
+ * @brief Base class for n-joint BLMC robots.
  *
  * This is a generic base class to easily implement drivers for simple BLMC
  * robots that consist of N_JOINTS joints.
@@ -355,7 +355,10 @@ private:
 };
 
 /**
- * TODO
+ * @brief Simple n-joint robot driver that uses NJointObservation.
+ *
+ * @tparam N_JOINTS  Number of joints
+ * @tparam N_MOTOR_BOARDS  Number of motor boards.
  */
 template <size_t N_JOINTS, size_t N_MOTOR_BOARDS = (N_JOINTS + 1) / 2>
 class SimpleNJointBlmcRobotDriver

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -53,18 +53,17 @@ struct MotorParameters
  * @tparam N_JOINTS Number of joints.
  * @tparam N_MOTOR_BOARDS Number of motor control boards that are used.
  */
-template <size_t N_JOINTS, size_t N_MOTOR_BOARDS>
+template <typename Observation, size_t N_JOINTS, size_t N_MOTOR_BOARDS>
 class NJointBlmcRobotDriver
     : public robot_interfaces::RobotDriver<
-          typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Action,
-          typename robot_interfaces::NJointRobotTypes<N_JOINTS>::Observation>
+          typename robot_interfaces::Action<N_JOINTS>,
+          Observation>
 {
 public:
-    typedef typename robot_interfaces::NJointRobotTypes<N_JOINTS> Types;
+    typedef typename robot_interfaces::Action<N_JOINTS> Action;
+    typedef typename robot_interfaces::RobotInterfaceTypes<Action, Observation> Types;
 
-    typedef typename Types::Action Action;
-    typedef typename Types::Observation Observation;
-    typedef typename Types::Vector Vector;
+    typedef typename Types::Action::Vector Vector;  // FIXME ?
     typedef std::array<std::shared_ptr<blmc_drivers::MotorInterface>, N_JOINTS>
         Motors;
     typedef std::array<std::shared_ptr<blmc_drivers::CanBusMotorBoard>,

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -18,7 +18,6 @@
 #include <yaml_cpp_catkin/yaml_eigen.h>
 #include <mpi_cpp_tools/math.hpp>
 #include <robot_interfaces/monitored_robot_driver.hpp>
-#include <robot_interfaces/n_joint_robot_functions.hpp>
 #include <robot_interfaces/n_joint_robot_types.hpp>
 #include <robot_interfaces/robot_driver.hpp>
 
@@ -172,7 +171,7 @@ public:
      *
      * @return Resulting action after applying all the processing.
      */
-    // FIXME
+    // FIXME move to hxx
     static typename Types::Action process_desired_action(
         const typename Types::Action &desired_action,
         const typename Types::Observation &latest_observation,
@@ -415,7 +414,7 @@ private:
 /**
  * TODO
  */
-template <size_t N_JOINTS, size_t N_MOTOR_BOARDS>
+template <size_t N_JOINTS, size_t N_MOTOR_BOARDS = (N_JOINTS + 1) / 2>
 class SimpleNJointBlmcRobotDriver
     : public NJointBlmcRobotDriver<
           robot_interfaces::NJointObservation<N_JOINTS>,

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -171,70 +171,13 @@ public:
      *
      * @return Resulting action after applying all the processing.
      */
-    // FIXME move to hxx
-    static typename Types::Action process_desired_action(
-        const typename Types::Action &desired_action,
-        const typename Types::Observation &latest_observation,
+    static Action process_desired_action(
+        const Action &desired_action,
+        const Observation &latest_observation,
         const double max_torque_Nm,
-        const typename Types::Action::Vector &safety_kd,
-        const typename Types::Action::Vector &default_position_control_kp,
-        const typename Types::Action::Vector &default_position_control_kd)
-    {
-        typename Types::Action processed_action;
-
-        processed_action.torque = desired_action.torque;
-        processed_action.position = desired_action.position;
-
-        // Position controller
-        // -------------------
-        // TODO: add position limits
-
-        // Run the position controller only if a target position is set for at
-        // least one joint.
-        if (!processed_action.position.array().isNaN().all())
-        {
-            // Replace NaN-values with default gains
-            processed_action.position_kp =
-                desired_action.position_kp.array().isNaN().select(
-                    default_position_control_kp, desired_action.position_kp);
-            processed_action.position_kd =
-                desired_action.position_kd.array().isNaN().select(
-                    default_position_control_kd, desired_action.position_kd);
-
-            typename Types::Action::Vector position_error =
-                processed_action.position - latest_observation.position;
-
-            // simple PD controller
-            typename Types::Action::Vector position_control_torque =
-                processed_action.position_kp.cwiseProduct(position_error) -
-                processed_action.position_kd.cwiseProduct(
-                    latest_observation.velocity);
-
-            // position_control_torque contains NaN for joints where target
-            // position is set to NaN!  Filter those out and set the torque to
-            // zero instead.
-            position_control_torque =
-                position_control_torque.array().isNaN().select(
-                    0, position_control_torque);
-
-            // Add result of position controller to the torque command
-            processed_action.torque += position_control_torque;
-        }
-
-        // Safety Checks
-        // -------------
-        // limit to configured maximum torque
-        processed_action.torque =
-            mct::clamp(processed_action.torque, -max_torque_Nm, max_torque_Nm);
-        // velocity damping to prevent too fast movements
-        processed_action.torque -=
-            safety_kd.cwiseProduct(latest_observation.velocity);
-        // after applying checks, make sure we are still below the max. torque
-        processed_action.torque =
-            mct::clamp(processed_action.torque, -max_torque_Nm, max_torque_Nm);
-
-        return processed_action;
-    }
+        const Vector &safety_kd,
+        const Vector &default_position_control_kp,
+        const Vector &default_position_control_kd);
 
 protected:
     BlmcJointModules<N_JOINTS> joint_modules_;

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -132,7 +132,7 @@ public:
      */
     void initialize() override;
 
-    virtual Observation get_latest_observation() = 0;
+    virtual Observation get_latest_observation() override = 0;
     Action apply_action(const Action &desired_action) override;
     std::string get_error() override;
     void shutdown() override;

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -66,7 +66,7 @@ public:
     typedef typename robot_interfaces::RobotInterfaceTypes<Action, Observation>
         Types;
 
-    typedef typename Action::Vector Vector;  // FIXME ?
+    typedef typename Action::Vector Vector;
     typedef std::array<std::shared_ptr<blmc_drivers::MotorInterface>, N_JOINTS>
         Motors;
     typedef std::array<std::shared_ptr<blmc_drivers::CanBusMotorBoard>,

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -211,11 +211,11 @@ typename NJBRD::Observation NJBRD::get_latest_observation()
         blmc_drivers::MotorBoardInterface::MeasurementIndex::analog_1);
     if (adc_a_history->length() == 0)
     {
-        observation.tip_force = std::numeric_limits<double>::quiet_NaN();
+        //observation.tip_force = std::numeric_limits<double>::quiet_NaN();
     }
     else
     {
-        observation.tip_force = adc_a_history->newest_element();
+        //observation.tip_force = adc_a_history->newest_element();
     }
 
     return observation;

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -201,9 +201,23 @@ TPL_NJBRD
 typename NJBRD::Observation NJBRD::get_latest_observation()
 {
     Observation observation;
+
     observation.position = joint_modules_.get_measured_angles();
     observation.velocity = joint_modules_.get_measured_velocities();
     observation.torque = joint_modules_.get_measured_torques();
+
+    // The force sensor is supposed to be connected to ADC A on board 0
+    auto adc_a_history = motor_boards_[0]->get_measurement(
+        blmc_drivers::MotorBoardInterface::MeasurementIndex::analog_0);
+    if (adc_a_history->length() == 0)
+    {
+        observation.tip_force = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+        observation.tip_force = adc_a_history->newest_element();
+    }
+
     return observation;
 }
 

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -208,7 +208,7 @@ typename NJBRD::Observation NJBRD::get_latest_observation()
 
     // The force sensor is supposed to be connected to ADC A on board 0
     auto adc_a_history = motor_boards_[0]->get_measurement(
-        blmc_drivers::MotorBoardInterface::MeasurementIndex::analog_0);
+        blmc_drivers::MotorBoardInterface::MeasurementIndex::analog_1);
     if (adc_a_history->length() == 0)
     {
         observation.tip_force = std::numeric_limits<double>::quiet_NaN();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,4 @@ target_compile_definitions(${test_name}_ut PUBLIC
 endmacro(create_blmc_robots_unittest test_name)
 
 create_blmc_robots_unittest(polynomes)
+create_blmc_robots_unittest(process_action)

--- a/tests/test_process_action.cpp
+++ b/tests/test_process_action.cpp
@@ -1,0 +1,347 @@
+/**
+ * @file
+ * @brief Test for processing of robot actions
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ *            Gesellschaft.
+ */
+#include <gtest/gtest.h>
+#include <robot_interfaces/n_joint_robot_types.hpp>
+#include <blmc_robots/n_joint_blmc_robot_driver.hpp>
+
+/**
+ * @brief Fixture for the tests of process_desired_action().
+ */
+class TestProcessDesiredAction : public ::testing::Test
+{
+protected:
+    using Types = robot_interfaces::SimpleNJointRobotTypes<2>;
+    using Driver = blmc_robots::SimpleNJointBlmcRobotDriver<2>;
+    using Vector = Types::Action::Vector;
+
+    Types::Observation observation;
+    double max_torque_Nm;
+    Vector safety_kd;
+    Vector default_position_control_kp;
+    Vector default_position_control_kd;
+
+    void SetUp() override
+    {
+        // set some arbitrary default values.  Tests can overwrite specific
+        // values if needed.
+        observation.position << 12.34, -0.42;
+        observation.velocity << .4, -.2;
+        observation.torque << 0.3, -0.25;
+
+        max_torque_Nm = 0.3;
+        safety_kd << 0.1, 0.1;
+
+        default_position_control_kp << 3, 4;
+        default_position_control_kd << .3, .4;
+    }
+};
+
+/**
+ * @brief Test if a valid torque command is returned unchanged (no safety).
+ */
+TEST_F(TestProcessDesiredAction, valid_torque_no_safety)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    Vector desired_torque;
+    desired_torque << 0.1, 0.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    ASSERT_EQ(desired_torque[0], resulting_action.torque[0]);
+    ASSERT_EQ(desired_torque[1], resulting_action.torque[1]);
+}
+
+/**
+ * @brief Test if clamping to max. torque is working.
+ */
+TEST_F(TestProcessDesiredAction, exceed_max_torque_no_safety)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    Vector desired_torque;
+    desired_torque << 0.5, -1.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    ASSERT_EQ(max_torque_Nm, resulting_action.torque[0]);
+    ASSERT_EQ(-max_torque_Nm, resulting_action.torque[1]);
+}
+
+/**
+ * @brief Test velocity damping with low velocity
+ */
+TEST_F(TestProcessDesiredAction, velocity_damping_low_velocity)
+{
+    Vector desired_torque;
+    desired_torque << 0.1, 0.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // joint 0 has positive velocity so expecting a reduced torque.
+    // joint 1 has negative velocity so expecting an increased torque.
+    // both should remain within the max. torque range.
+    ASSERT_LT(resulting_action.torque[0], desired_torque[0]);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
+    ASSERT_GT(resulting_action.torque[1], desired_torque[1]);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
+}
+
+/**
+ * @brief Test velocity damping with very high velocity.
+ *
+ * This test ensures that torques cannot exceed the allowed max. torque due to
+ * the velocity damping.
+ */
+TEST_F(TestProcessDesiredAction, velocity_damping_high_velocity)
+{
+    // set very high velocity
+    observation.velocity << 4000, -2000;
+
+    Vector desired_torque;
+    desired_torque << 0.1, 0.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // joint 0 has positive velocity so expecting a reduced torque.
+    // joint 1 has negative velocity so expecting an increased torque.
+    // both should remain within the max. torque range.
+    ASSERT_LT(resulting_action.torque[0], desired_torque[0]);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
+    ASSERT_GT(resulting_action.torque[1], desired_torque[1]);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
+}
+
+/**
+ * @brief Test basic position controller (default gains, no velocity)
+ */
+TEST_F(TestProcessDesiredAction, position_controller_basic)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position;
+    desired_position << -1, 1;
+    Types::Action action = Types::Action::Position(desired_position);
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // Just testing here if the torque command goes in the right direction
+
+    ASSERT_LT(resulting_action.torque[0], 0.0);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
+
+    ASSERT_GT(resulting_action.torque[1], 0.0);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
+
+    // verify that position and gains are set correctly in the returned action
+    ASSERT_EQ(desired_position[0], resulting_action.position[0]);
+    ASSERT_EQ(desired_position[1], resulting_action.position[1]);
+    ASSERT_EQ(default_position_control_kp[0], resulting_action.position_kp[0]);
+    ASSERT_EQ(default_position_control_kp[1], resulting_action.position_kp[1]);
+    ASSERT_EQ(default_position_control_kd[0], resulting_action.position_kd[0]);
+    ASSERT_EQ(default_position_control_kd[1], resulting_action.position_kd[1]);
+}
+
+/**
+ * @brief Test position controller for only one joint.
+ */
+TEST_F(TestProcessDesiredAction, position_controller_one_joint_only)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position;
+    desired_position << -1, std::numeric_limits<double>::quiet_NaN();
+    Types::Action action = Types::Action::Position(desired_position);
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // Just testing here if the torque command goes in the right direction
+    ASSERT_LT(resulting_action.torque[0], 0.0);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
+
+    // desired position for joint 1 is nan, so no torque should be generated
+    ASSERT_EQ(0.0, resulting_action.torque[1]);
+}
+
+/**
+ * @brief Test position control with velocity (i.e. verifying D-gain is working)
+ */
+TEST_F(TestProcessDesiredAction, position_controller_with_velocity)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position;
+    // use low position change to not saturate torques
+    desired_position << -.01, .01;
+
+    Types::Action result_action_without_velocity =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    observation.velocity << -.01, .01;
+
+    Types::Action result_action_with_velocity =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    // Since velocity has same sign as position error, the resulting
+    // (absolute) torques should be lower (since it is
+    //   torque = P * position_error - D * velocity )
+    EXPECT_LT(result_action_without_velocity.torque[0],
+              result_action_with_velocity.torque[0]);
+    EXPECT_GT(result_action_without_velocity.torque[1],
+              result_action_with_velocity.torque[1]);
+}
+
+/**
+ * @brief Test position control with custom gains.
+ */
+TEST_F(TestProcessDesiredAction, position_controller_custom_gains)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position, kp, kd;
+    // use low position change to not saturate torques with lower gains
+    desired_position << -.01, .01;
+    // set gains significantly higher than the default gains above
+    kp << 10, 10;
+    kd << 5, 5;
+
+    Types::Action resulting_action_default_gains =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    Types::Action resulting_action_custom_gains =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position, kp, kd),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    // verify that custom gains are set in resulting action
+    EXPECT_EQ(kp[0], resulting_action_custom_gains.position_kp[0]);
+    EXPECT_EQ(kp[1], resulting_action_custom_gains.position_kp[1]);
+    EXPECT_EQ(kd[0], resulting_action_custom_gains.position_kd[0]);
+    EXPECT_EQ(kd[1], resulting_action_custom_gains.position_kd[1]);
+
+    // Since custom gains are higher, the resulting (absolute) torques should be
+    // higher
+    EXPECT_GT(resulting_action_default_gains.torque[0],
+              resulting_action_custom_gains.torque[0]);
+    EXPECT_LT(resulting_action_default_gains.torque[1],
+              resulting_action_custom_gains.torque[1]);
+}
+
+/**
+ * @brief Test combined torque and position control.
+ */
+TEST_F(TestProcessDesiredAction, position_controller_and_torque)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_torque;
+    desired_torque << -0.2, 0.2;
+    Vector desired_position;
+    desired_position << -.1, .1;
+    Types::Action action =
+        Types::Action::TorqueAndPosition(desired_torque, desired_position);
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // Just testing here if the torque command goes in the right direction
+
+    ASSERT_LT(resulting_action.torque[0], desired_torque[0]);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
+
+    ASSERT_GT(resulting_action.torque[1], desired_torque[1]);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
+}


### PR DESCRIPTION
## Summary
Restructure `NJointBlmcRobotDriver` to enable extension of the observation (e.g. to add force sensors).

## Description
- To allow extension of the observation, add the observation type as template parameter to `NJointBlmcRobotDriver` and keep `get_latest_observation` pure virtual.
- Add `SimpleNJointBlmcRobotDriver` which implements what `NJointBlmcRobotDriver` was in the past.
- Move `process_desired_action` back to `NJointBlmcRobotDriver` as this makes handling the templated observation easier (but keep it static).  Also move the corresponding unit tests from robot_interfaces to here.

## How I Tested

Running the some demos.  Did not test with an actual sensor connected but general control of the robot still works as expected.


## Merge together with

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/61
- [x] https://github.com/open-dynamic-robot-initiative/robot_fingers/pull/18

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
