### PR TITLE
Add joint limits to NJointBlmcRobotDriver

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -335,7 +335,7 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
      *
      * @param position Joint positions.
      *
-     * @return True if `joint_lower_limits < position < joint_upper_limits`.
+     * @return True if `joint_lower_limits <= position <= joint_upper_limits`.
      */
     bool is_within_joint_limits(const Vector &position) const;
 

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -179,6 +179,14 @@ public:
         const Vector &default_position_control_kp,
         const Vector &default_position_control_kd);
 
+
+    /**
+     * @brief Check if the joint position is within the allowed limits.
+     *
+     * @see Config::is_within_joint_limits
+     */
+    bool is_within_joint_limits(const Observation &observation) const;
+
 protected:
     BlmcJointModules<N_JOINTS> joint_modules_;
     MotorBoards motor_boards_;
@@ -296,7 +304,7 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
         double move_timeout = 0.0;
     } calibration;
 
-    //! \brief D-gain to dampen velocity.  Set to zero to disable damping.
+    //! @brief D-gain to dampen velocity.  Set to zero to disable damping.
     // set some rather high damping by default
     Vector safety_kd = Vector::Constant(0.1);
 
@@ -307,7 +315,12 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
         Vector kd = Vector::Zero();
     } position_control_gains;
 
-    //! \brief Offset between home position and zero.
+    //! @brief Lower limits for joint position.
+    Vector joint_lower_limits = Vector::Zero();
+    //! @brief Upper limits for joint position.
+    Vector joint_upper_limits = Vector::Zero();
+
+    //! @brief Offset between home position and zero.
     Vector home_offset_rad = Vector::Zero();
 
     /**
@@ -315,6 +328,16 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
      *        initialization.
      */
     Vector initial_position_rad = Vector::Zero();
+
+
+    /**
+     * @brief Check if the given position is within the joint limits.
+     *
+     * @param position Joint positions.
+     *
+     * @return True if `joint_lower_limits < position < joint_upper_limits`.
+     */
+    bool is_within_joint_limits(const Vector &position) const;
 
     /**
      * @brief Print the given configuration in a human-readable way.

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -14,8 +14,8 @@ namespace blmc_robots
 TPL_NJBRD
 bool NJBRD::Config::is_within_joint_limits(const Vector &position) const
 {
-    return (joint_lower_limits.array() < position.array()).all() &&
-           (position.array() < joint_upper_limits.array()).all();
+    return (joint_lower_limits.array() <= position.array()).all() &&
+           (position.array() <= joint_upper_limits.array()).all();
 }
 
 TPL_NJBRD

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -282,6 +282,18 @@ std::string NJBRD::get_error()
         }
     }
 
+    // check if position is within the limits
+    Vector position = this->joint_modules_.get_measured_angles();
+    if (!config_.is_within_joint_limits(position))
+    {
+        if (!error_msg.empty())
+        {
+            error_msg += " | ";
+        }
+
+        error_msg += "Position limits exceeded.";
+    }
+
     return error_msg;
 }
 
@@ -305,9 +317,10 @@ typename NJBRD::Action NJBRD::process_desired_action(
     processed_action.torque = desired_action.torque;
     processed_action.position = desired_action.position;
 
+    // TODO if desired position exceeds allowed limits, clamp it?
+
     // Position controller
     // -------------------
-    // TODO: add position limits
 
     // Run the position controller only if a target position is set for at
     // least one joint.

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -12,6 +12,13 @@
 namespace blmc_robots
 {
 TPL_NJBRD
+bool NJBRD::Config::is_within_joint_limits(const Vector &position) const
+{
+    return (joint_lower_limits.array() < position.array()).all() &&
+           (position.array() < joint_upper_limits.array()).all();
+}
+
+TPL_NJBRD
 void NJBRD::Config::print() const
 {
     std::cout << "Configuration:\n"
@@ -23,18 +30,19 @@ void NJBRD::Config::print() const
     std::cout << "\n"
               << "\t max_current_A: " << max_current_A << "\n"
               << "\t has_endstop: " << has_endstop << "\n"
-              << "\t calibration: "
-              << "\n"
+              << "\t calibration:\n"
               << "\t\t endstop_search_torques_Nm: "
               << calibration.endstop_search_torques_Nm.transpose() << "\n"
               << "\t\t position_tolerance_rad: "
               << calibration.position_tolerance_rad << "\n"
               << "\t\t move_timeout: " << calibration.move_timeout << "\n"
               << "\t safety_kd: " << safety_kd.transpose() << "\n"
-              << "\t position_control_gains: "
-              << "\n"
+              << "\t position_control_gains:\n"
               << "\t\t kp: " << position_control_gains.kp.transpose() << "\n"
               << "\t\t kd: " << position_control_gains.kd.transpose() << "\n"
+              << "\t joint_limits:\n"
+              << "\t\t lower: " << joint_lower_limits.transpose() << "\n"
+              << "\t\t upper: " << joint_upper_limits.transpose() << "\n"
               << "\t home_offset_rad: " << home_offset_rad.transpose() << "\n"
               << "\t initial_position_rad: " << initial_position_rad.transpose()
               << "\n"
@@ -107,6 +115,11 @@ typename NJBRD::Config NJBRD::Config::load_config(
         set_config_value(pos_ctrl, "kp", &config.position_control_gains.kp);
         set_config_value(pos_ctrl, "kd", &config.position_control_gains.kd);
     }
+
+    set_config_value(
+        user_config, "joint_lower_limits", &config.joint_lower_limits);
+    set_config_value(
+        user_config, "joint_upper_limits", &config.joint_upper_limits);
 
     set_config_value(user_config, "home_offset_rad", &config.home_offset_rad);
     set_config_value(
@@ -341,6 +354,12 @@ typename NJBRD::Action NJBRD::process_desired_action(
         mct::clamp(processed_action.torque, -max_torque_Nm, max_torque_Nm);
 
     return processed_action;
+}
+
+TPL_NJBRD
+bool NJBRD::is_within_joint_limits(const Observation &observation) const
+{
+    return config_.is_within_joint_limits(observation.position);
 }
 
 TPL_NJBRD

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,3 +29,4 @@ endmacro(create_blmc_robots_unittest test_name)
 
 create_blmc_robots_unittest(polynomes)
 create_blmc_robots_unittest(process_action)
+create_blmc_robots_unittest(n_joint_blmc_robot_driver)

--- a/tests/test_n_joint_blmc_robot_driver.cpp
+++ b/tests/test_n_joint_blmc_robot_driver.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * @brief Test for NJointBlmcRobotDriver.
+ * @copyright Copyright (c) 2020, New York University & Max Planck Gesellschaft.
+ */
+#include <gtest/gtest.h>
+#include <blmc_robots/n_joint_blmc_robot_driver.hpp>
+
+using Driver = blmc_robots::SimpleNJointBlmcRobotDriver<2>;
+
+TEST(TestNJointBlmcRobotDriverConfig, is_within_joint_limits)
+{
+    Driver::Config config;
+    config.joint_lower_limits << -1.0, 0;
+    config.joint_upper_limits << +0.5, +1.0;
+
+    // bounds are exclusive
+    ASSERT_FALSE(config.is_within_joint_limits(config.joint_lower_limits));
+    ASSERT_FALSE(config.is_within_joint_limits(config.joint_upper_limits));
+
+    // some positions outside the limits
+    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-2, -1)));
+    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-2, 0.5)));
+    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-0.5, -1)));
+    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-0.5, 2)));
+    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(1, 2)));
+    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(1, 0.5)));
+
+    // some positions inside the limits
+    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0, 0.3)));
+    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(-0.9, 0.9)));
+    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0.4, 0.1)));
+}

--- a/tests/test_n_joint_blmc_robot_driver.cpp
+++ b/tests/test_n_joint_blmc_robot_driver.cpp
@@ -14,9 +14,14 @@ TEST(TestNJointBlmcRobotDriverConfig, is_within_joint_limits)
     config.joint_lower_limits << -1.0, 0;
     config.joint_upper_limits << +0.5, +1.0;
 
-    // bounds are exclusive
-    ASSERT_FALSE(config.is_within_joint_limits(config.joint_lower_limits));
-    ASSERT_FALSE(config.is_within_joint_limits(config.joint_upper_limits));
+    // bounds are inclusive
+    ASSERT_TRUE(config.is_within_joint_limits(config.joint_lower_limits));
+    ASSERT_TRUE(config.is_within_joint_limits(config.joint_upper_limits));
+
+    // some positions inside the limits
+    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0, 0.3)));
+    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(-0.9, 0.9)));
+    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0.4, 0.1)));
 
     // some positions outside the limits
     ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-2, -1)));
@@ -25,9 +30,4 @@ TEST(TestNJointBlmcRobotDriverConfig, is_within_joint_limits)
     ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-0.5, 2)));
     ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(1, 2)));
     ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(1, 0.5)));
-
-    // some positions inside the limits
-    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0, 0.3)));
-    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(-0.9, 0.9)));
-    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0.4, 0.1)));
 }


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Add joint limits that need to be specified in the configuration.  When a joint exceeds its limits, an error is triggered.


## How I Tested

Using FingerOne and TriFingerOne, moving the joints manually out of the range.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/robot_fingers/pull/23

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
