### PR TITLE
Soft joint position limits for NJointBlmcRobotDriver

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -192,11 +192,11 @@ public:
             Vector::Constant(std::numeric_limits<double>::infinity()));
 
     /**
-     * @brief Check if the joint position is within the allowed limits.
+     * @brief Check if the joint position is within the hard limits.
      *
-     * @see Config::is_within_joint_limits
+     * @see Config::is_within_hard_position_limits
      */
-    bool is_within_joint_limits(const Observation &observation) const;
+    bool is_within_hard_position_limits(const Observation &observation) const;
 
 protected:
     BlmcJointModules<N_JOINTS> joint_modules_;
@@ -326,10 +326,35 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
         Vector kd = Vector::Zero();
     } position_control_gains;
 
-    //! @brief Lower limits for joint position.
-    Vector joint_lower_limits = Vector::Zero();
-    //! @brief Upper limits for joint position.
-    Vector joint_upper_limits = Vector::Zero();
+    /**
+     * @brief Hard lower limits for joint position.
+     *
+     * Exceeding this limit results in an error and robot shutdown.
+     */
+    Vector hard_position_limits_lower = Vector::Zero();
+    /**
+     * @brief Hard upper limits for joint position.
+     *
+     * Exceeding this limit results in an error and robot shutdown.
+     */
+    Vector hard_position_limits_upper = Vector::Zero();
+
+    /**
+     * @brief Soft lower limits for joint position.
+     *
+     * Exceeding this limit results in the action being adjusted to move the
+     * joint back inside the limits.
+     */
+    Vector soft_position_limits_lower =
+        Vector::Constant(-std::numeric_limits<double>::infinity());
+    /**
+     * @brief Soft upper limits for joint position.
+     *
+     * Exceeding this limit results in the action being adjusted to move the
+     * joint back inside the limits.
+     */
+    Vector soft_position_limits_upper =
+        Vector::Constant(std::numeric_limits<double>::infinity());
 
     //! @brief Offset between home position and zero.
     Vector home_offset_rad = Vector::Zero();
@@ -342,13 +367,14 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
 
 
     /**
-     * @brief Check if the given position is within the joint limits.
+     * @brief Check if the given position is within the hard limits.
      *
      * @param position Joint positions.
      *
-     * @return True if `joint_lower_limits <= position <= joint_upper_limits`.
+     * @return True if `hard_position_limits_lower <= position <=
+     *     hard_position_limits_upper`.
      */
-    bool is_within_joint_limits(const Vector &position) const;
+    bool is_within_hard_position_limits(const Vector &position) const;
 
     /**
      * @brief Print the given configuration in a human-readable way.

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -144,9 +144,10 @@ public:
      *
      * ## 1. Check position limits
      *
-     *   If the observed position of a joint exceeds the limits, the action for
-     *   this joint is overwritten with a position command to the limit value
-     *   using the default PD-gains.
+     *   If the observed position of a joint exceeds the limits, actions for
+     *   that joint that do not point back towards the allowed range are
+     *   replaced with a position command to the limit value.  Further custom
+     *   PD-gains are ignored in this case.
      *
      * ## 2. Run the position controller in case a target position is set.
      *

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -142,7 +142,13 @@ public:
      *
      * Takes the desired action from the user and does the following processing:
      *
-     * ## 1. Run the position controller in case a target position is set.
+     * ## 1. Check position limits
+     *
+     *   If the observed position of a joint exceeds the limits, the action for
+     *   this joint is overwritten with a position command to the limit value
+     *   using the default PD-gains.
+     *
+     * ## 2. Run the position controller in case a target position is set.
      *
      *   If the target position is set to a value unequal to NaN for any joint,
      *   a PD position controller is executed for this joint and the resulting
@@ -152,7 +158,7 @@ public:
      *   are used for the control.  NaN-values are replaced with the default
      *   gains.
      *
-     * ## 2. Apply safety checks.
+     * ## 3. Apply safety checks.
      *
      *   - Limit the torque to the allowed maximum value.
      *   - Dampen velocity using the given safety_kd gains.  Damping us done
@@ -168,6 +174,8 @@ public:
      * @param safety_kd  D-gain for velocity damping.
      * @param default_position_control_kp  Default P-gain for position control.
      * @param default_position_control_kd  Default D-gain for position control.
+     * @param lower_position_limits  Lower limits for joint positions.
+     * @param upper_position_limits  Upper limits for joint positions.
      *
      * @return Resulting action after applying all the processing.
      */
@@ -177,8 +185,11 @@ public:
         const double max_torque_Nm,
         const Vector &safety_kd,
         const Vector &default_position_control_kp,
-        const Vector &default_position_control_kd);
-
+        const Vector &default_position_control_kd,
+        const Vector &lower_position_limits =
+            Vector::Constant(-std::numeric_limits<double>::infinity()),
+        const Vector &upper_position_limits =
+            Vector::Constant(std::numeric_limits<double>::infinity()));
 
     /**
      * @brief Check if the joint position is within the allowed limits.

--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -427,13 +427,26 @@ typename NJBRD::Action NJBRD::apply_action_uninitialized(
 
     Observation observation = get_latest_observation();
 
+    // Only enable soft position limits once initialization is done (i.e. no
+    // limits during homing).
+    Vector lower_limits =
+        is_initialized_
+            ? config_.soft_position_limits_lower
+            : Vector::Constant(-std::numeric_limits<double>::infinity());
+    Vector upper_limits =
+        is_initialized_
+            ? config_.soft_position_limits_upper
+            : Vector::Constant(std::numeric_limits<double>::infinity());
+
     Action applied_action =
         process_desired_action(desired_action,
                                observation,
                                max_torque_Nm_,
                                config_.safety_kd,
                                config_.position_control_gains.kp,
-                               config_.position_control_gains.kd);
+                               config_.position_control_gains.kd,
+                               lower_limits,
+                               upper_limits);
 
     joint_modules_.set_torques(applied_action.torque);
     joint_modules_.send_torques();

--- a/tests/test_n_joint_blmc_robot_driver.cpp
+++ b/tests/test_n_joint_blmc_robot_driver.cpp
@@ -11,23 +11,30 @@ using Driver = blmc_robots::SimpleNJointBlmcRobotDriver<2>;
 TEST(TestNJointBlmcRobotDriverConfig, is_within_joint_limits)
 {
     Driver::Config config;
-    config.joint_lower_limits << -1.0, 0;
-    config.joint_upper_limits << +0.5, +1.0;
+    config.hard_position_limits_lower << -1.0, 0;
+    config.hard_position_limits_upper << +0.5, +1.0;
 
     // bounds are inclusive
-    ASSERT_TRUE(config.is_within_joint_limits(config.joint_lower_limits));
-    ASSERT_TRUE(config.is_within_joint_limits(config.joint_upper_limits));
+    ASSERT_TRUE(config.is_within_hard_position_limits(
+        config.hard_position_limits_lower));
+    ASSERT_TRUE(config.is_within_hard_position_limits(
+        config.hard_position_limits_upper));
 
     // some positions inside the limits
-    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0, 0.3)));
-    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(-0.9, 0.9)));
-    ASSERT_TRUE(config.is_within_joint_limits(Driver::Vector(0.4, 0.1)));
+    ASSERT_TRUE(config.is_within_hard_position_limits(Driver::Vector(0, 0.3)));
+    ASSERT_TRUE(
+        config.is_within_hard_position_limits(Driver::Vector(-0.9, 0.9)));
+    ASSERT_TRUE(
+        config.is_within_hard_position_limits(Driver::Vector(0.4, 0.1)));
 
     // some positions outside the limits
-    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-2, -1)));
-    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-2, 0.5)));
-    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-0.5, -1)));
-    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(-0.5, 2)));
-    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(1, 2)));
-    ASSERT_FALSE(config.is_within_joint_limits(Driver::Vector(1, 0.5)));
+    ASSERT_FALSE(config.is_within_hard_position_limits(Driver::Vector(-2, -1)));
+    ASSERT_FALSE(
+        config.is_within_hard_position_limits(Driver::Vector(-2, 0.5)));
+    ASSERT_FALSE(
+        config.is_within_hard_position_limits(Driver::Vector(-0.5, -1)));
+    ASSERT_FALSE(
+        config.is_within_hard_position_limits(Driver::Vector(-0.5, 2)));
+    ASSERT_FALSE(config.is_within_hard_position_limits(Driver::Vector(1, 2)));
+    ASSERT_FALSE(config.is_within_hard_position_limits(Driver::Vector(1, 0.5)));
 }

--- a/tests/test_process_action.cpp
+++ b/tests/test_process_action.cpp
@@ -344,3 +344,196 @@ TEST_F(TestProcessDesiredAction, position_controller_and_torque)
     ASSERT_GT(resulting_action.torque[1], desired_torque[1]);
     ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
 }
+
+
+TEST_F(TestProcessDesiredAction, position_within_limits)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+
+    Vector limits;
+    limits << 1, 2;
+
+    Vector desired_position, kp, kd;
+    // use low position change to not saturate torques with lower gains
+    desired_position << -.01, .01;
+    // set gains significantly higher than the default gains above
+    kp << 10, 10;
+    kd << 5, 5;
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position, kp, kd),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd,
+            -limits,
+            limits);
+
+    EXPECT_EQ(desired_position[0], resulting_action.position[0]);
+    EXPECT_EQ(desired_position[1], resulting_action.position[1]);
+    // verify that custom gains are set in resulting action
+    EXPECT_EQ(kp[0], resulting_action.position_kp[0]);
+    EXPECT_EQ(kp[1], resulting_action.position_kp[1]);
+    EXPECT_EQ(kd[0], resulting_action.position_kd[0]);
+    EXPECT_EQ(kd[1], resulting_action.position_kd[1]);
+}
+
+
+TEST_F(TestProcessDesiredAction, position_below_limits)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << -3, -3;
+
+    Vector limits;
+    limits << 1, 2;
+
+    Vector desired_position, kp, kd;
+    // use low position change to not saturate torques with lower gains
+    desired_position << -.01, .01;
+    // set gains significantly higher than the default gains above
+    kp << 10, 10;
+    kd << 5, 5;
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position, kp, kd),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd,
+            -limits,
+            limits);
+
+    // verify that position is set to limit and custom gains are ignored
+    EXPECT_EQ(-limits[0], resulting_action.position[0]);
+    EXPECT_EQ(-limits[1], resulting_action.position[1]);
+    EXPECT_EQ(default_position_control_kp[0], resulting_action.position_kp[0]);
+    EXPECT_EQ(default_position_control_kp[1], resulting_action.position_kp[1]);
+    EXPECT_EQ(default_position_control_kd[0], resulting_action.position_kd[0]);
+    EXPECT_EQ(default_position_control_kd[1], resulting_action.position_kd[1]);
+}
+
+
+TEST_F(TestProcessDesiredAction, position_above_limits)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 3, 3;
+
+    Vector limits;
+    limits << 1, 2;
+
+    Vector desired_position, kp, kd;
+    // use low position change to not saturate torques with lower gains
+    desired_position << -.01, .01;
+    // set gains significantly higher than the default gains above
+    kp << 10, 10;
+    kd << 5, 5;
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position, kp, kd),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd,
+            -limits,
+            limits);
+
+    // verify that position is set to limit and custom gains are ignored
+    EXPECT_EQ(limits[0], resulting_action.position[0]);
+    EXPECT_EQ(limits[1], resulting_action.position[1]);
+    EXPECT_EQ(default_position_control_kp[0], resulting_action.position_kp[0]);
+    EXPECT_EQ(default_position_control_kp[1], resulting_action.position_kp[1]);
+    EXPECT_EQ(default_position_control_kd[0], resulting_action.position_kd[0]);
+    EXPECT_EQ(default_position_control_kd[1], resulting_action.position_kd[1]);
+}
+
+
+TEST_F(TestProcessDesiredAction, position_one_joint_above_limit)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 3;
+
+    Vector limits;
+    limits << 1, 2;
+
+    Vector desired_position, kp, kd;
+    // use low position change to not saturate torques with lower gains
+    desired_position << -.01, .01;
+    // set gains significantly higher than the default gains above
+    kp << 10, 10;
+    kd << 5, 5;
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position, kp, kd),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd,
+            -limits,
+            limits);
+
+    // For joint 0 (within limits) desired position and gains should be used,
+    // for joint 1 (above limit), position and gains should be overwritten.
+    EXPECT_EQ(desired_position[0], resulting_action.position[0]);
+    EXPECT_EQ(kp[0], resulting_action.position_kp[0]);
+    EXPECT_EQ(kd[0], resulting_action.position_kd[0]);
+    EXPECT_EQ(limits[1], resulting_action.position[1]);
+    EXPECT_EQ(default_position_control_kp[1], resulting_action.position_kp[1]);
+    EXPECT_EQ(default_position_control_kd[1], resulting_action.position_kd[1]);
+}
+
+
+TEST_F(TestProcessDesiredAction, position_one_above_one_below_limit)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << -3, 3;
+
+    Vector limits;
+    limits << 1, 2;
+
+    Vector desired_position, kp, kd;
+    // use low position change to not saturate torques with lower gains
+    desired_position << -.01, .01;
+    // set gains significantly higher than the default gains above
+    kp << 10, 10;
+    kd << 5, 5;
+
+    Types::Action resulting_action =
+        Driver::process_desired_action(
+            Types::Action::Position(desired_position, kp, kd),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd,
+            -limits,
+            limits);
+
+    // Joint 0 is below limit, so position should be set to lower limit.  Joint
+    // 1 is above limit, so position should be set to upper limit.  For both
+    // joints, custom gains should be ignored.
+    EXPECT_EQ(-limits[0], resulting_action.position[0]);
+    EXPECT_EQ(limits[1], resulting_action.position[1]);
+    EXPECT_EQ(default_position_control_kp[0], resulting_action.position_kp[0]);
+    EXPECT_EQ(default_position_control_kp[1], resulting_action.position_kp[1]);
+    EXPECT_EQ(default_position_control_kd[0], resulting_action.position_kd[0]);
+    EXPECT_EQ(default_position_control_kd[1], resulting_action.position_kd[1]);
+}


### PR DESCRIPTION
## Description

Add optional position limit arguments to `process_desired_action()`.  If the observed position of a joint exceeds these limits, actions for that joint that do not move the joint back towards the valid range are overwritten with a position command to the limit value using the default PD-gains.

Add it as optional field to the robot configuration file format.  If not specified in the config file, the default values of -/+inf is used which effectively disables the feature.

## Open for Discussion
This is not using any hysteresis yet as I am not sure how to do this in a way that would actually avoid oscillation.  This means that right now the joint can vibrate at the limit position e.g. when simply sending a constant torque command that moves the joint beyond the limit.

## How I Tested

On TriFingerEdu.

## Merge together with
- [x] https://github.com/open-dynamic-robot-initiative/robot_fingers/pull/24

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
