### PR TITLE
Fix unit test for position limits

### DIFF
--- a/tests/test_process_action.cpp
+++ b/tests/test_process_action.cpp
@@ -395,9 +395,8 @@ TEST_F(TestProcessDesiredAction, position_below_limits)
     limits << 1, 2;
 
     Vector desired_position, kp, kd;
-    // use low position change to not saturate torques with lower gains
-    desired_position << -.01, .01;
-    // set gains significantly higher than the default gains above
+    // use current position as target to ensure they are outside the limits
+    desired_position = observation.position;
     kp << 10, 10;
     kd << 5, 5;
 
@@ -433,9 +432,8 @@ TEST_F(TestProcessDesiredAction, position_above_limits)
     limits << 1, 2;
 
     Vector desired_position, kp, kd;
-    // use low position change to not saturate torques with lower gains
-    desired_position << -.01, .01;
-    // set gains significantly higher than the default gains above
+    // use current position as target to ensure they are outside the limits
+    desired_position = observation.position;
     kp << 10, 10;
     kd << 5, 5;
 
@@ -471,9 +469,7 @@ TEST_F(TestProcessDesiredAction, position_one_joint_above_limit)
     limits << 1, 2;
 
     Vector desired_position, kp, kd;
-    // use low position change to not saturate torques with lower gains
-    desired_position << -.01, .01;
-    // set gains significantly higher than the default gains above
+    desired_position << -.01, 4;
     kp << 10, 10;
     kd << 5, 5;
 
@@ -510,9 +506,7 @@ TEST_F(TestProcessDesiredAction, position_one_above_one_below_limit)
     limits << 1, 2;
 
     Vector desired_position, kp, kd;
-    // use low position change to not saturate torques with lower gains
-    desired_position << -.01, .01;
-    // set gains significantly higher than the default gains above
+    desired_position << -4, 4;
     kp << 10, 10;
     kd << 5, 5;
 


### PR DESCRIPTION

## Description
Fix unit test for position limits.

With the latest change commands that attempt to move the joint back
inside the limits are not changed.  For the existing tests to pass with
this, set the position commands beyond the limits, so that they need to
be adjusted.



## How I Tested

By running the test locally.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
