### PR TITLE
Add missing dependency on mpi_cpp_tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CATKIN_PKGS ${CATKIN_PKGS}
   master_board_sdk_catkin
   real_time_tools
   mpi_cmake_modules
+  mpi_cpp_tools
   robot_interfaces
   pybind11_catkin
   yaml_cpp_catkin

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>master_board_sdk_catkin</depend>
   <depend>real_time_tools</depend>
   <depend>mpi_cmake_modules</depend>
+  <depend>mpi_cpp_tools</depend>
   <depend>robot_interfaces</depend>
   <depend>pybind11_catkin</depend>
   <depend>yaml_cpp_catkin</depend>


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The mpi_cpp_tools is used in this package but was not properly specified as dependency.


## How I Tested

Compiled.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
