### PR TITLE
Use minimum jerk trajectory in move_to_position()

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -254,19 +254,22 @@ protected:
                 Vector home_offset_rad = Vector::Zero());
 
     /**
-     * @brief Move to given goal position using PD control.
+     * @brief Move to given goal position with a minimum jerk trajectory.
+     *
+     * Use a series of position actions to move to the given goal position on a
+     * minimum jerk trajectory.
      *
      * @param goal_pos Angular goal position for each joint.
      * @param tolerance Allowed position error for reaching the goal.  This is
      *     checked per joint, that is the maximal possible error is +/-tolerance
      *     on each joint.
-     * @param timeout_cycles Timeout.  If exceeded before goal is reached, the
-     *     procedure is aborted. Unit: Number of control loop cycles.
+     * @param time_steps Number of control loop cycles for reaching the goal.
+     *     The lower the number of steps, the faster the robot will move.
      * @return True if goal position is reached, false if timeout is exceeded.
      */
     bool move_to_position(const Vector &goal_pos,
                           const double tolerance,
-                          const uint32_t timeout_cycles);
+                          const uint32_t time_steps);
 };
 
 /**
@@ -310,10 +313,10 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
     {
         //! @brief Torque that is used to find the end stop.
         Vector endstop_search_torques_Nm = Vector::Zero();
-        //! @brief Tolerance for reaching the starting position.
+        //! @brief Tolerance for reaching the initial position.
         double position_tolerance_rad = 0.0;
-        //! @brief Timeout for reaching the starting position.
-        double move_timeout = 0.0;
+        //! @brief Number of time steps for reaching the initial position.
+        uint32_t move_steps = 0;
     } calibration;
 
     //! @brief D-gain to dampen velocity.  Set to zero to disable damping.


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Instead of directly setting the goal position, move more smoothly on a trajectory that minimizes jerk.

This has several advantages:
 - less stress for the mechanics
 - lower power consumption(?)
 - automatically slows down towards the goal, so no need to explicitly stop the robot once the goal is reached.  This implicitly fixes the issue of the previous implementation that the zero-velocity threshold was not reached reliably if the controller is not tuned properly.

With this, there is no need for a timeout anymore.  Instead a number of time steps for the motion needs to be passed (the smaller this number, the faster the motion).



## How I Tested

On MonoFingerOne


## Do not merge before

- [ ] https://github.com/open-dynamic-robot-initiative/robot_fingers/pull/35

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
