### PR TITLE
NJointBlmcRobotDriver: Configurable "Shutdown Trajectory"

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -280,6 +280,16 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
 {
     typedef std::array<std::string, N_MOTOR_BOARDS> CanPortArray;
 
+    //! @brief A sub-goal of a trajectory.
+    struct TrajectoryStep
+    {
+        //! @brief Target position to which the joints should move.
+        Vector target_position_rad = Vector::Zero();
+
+        //! @brief Number of time steps for reaching the target position.
+        uint32_t move_steps = 0;
+    };
+
     // All parameters should have default values that should not result in
     // dangerous behaviour in case someone forgets to specify them.
 
@@ -313,11 +323,13 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
     {
         //! @brief Torque that is used to find the end stop.
         Vector endstop_search_torques_Nm = Vector::Zero();
-        //! @brief Tolerance for reaching the initial position.
-        double position_tolerance_rad = 0.0;
         //! @brief Number of time steps for reaching the initial position.
         uint32_t move_steps = 0;
     } calibration;
+
+    //! @brief Tolerance for reaching the target with
+    //!        @ref NJointBlmcRobotDriver::move_to_position.
+    double move_to_position_tolerance_rad = 0.0;
 
     //! @brief D-gain to dampen velocity.  Set to zero to disable damping.
     // set some rather high damping by default
@@ -368,6 +380,15 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
      *        initialization.
      */
     Vector initial_position_rad = Vector::Zero();
+
+    /**
+     * @brief Trajectory which is executed in the shutdown method.
+     *
+     * Use this to move the robot to a "rest position" during shutdown of the
+     * robot driver.  It can consist of arbitrarily many steps.  Leave it empty
+     * to not move during shutdown.
+     */
+    std::vector<TrajectoryStep> shutdown_trajectory;
 
     /**
      * @brief Check if the given position is within the hard limits.


### PR DESCRIPTION
## Description
Add optional parameter "shutdown_trajectory" to the configuration of the
driver.  If set, this parameter is expected to contain a list of target
positions.  During `shutdown()`, the robot is moved to these positions
one by one, using `move_to_position()`.
This can be used to move the robot to a safe rest position before
turning it of.

Since this also needs the `position_tolerance_rad` parameter to
determine if the goal is reached, move this one out of `calibration` and
rename it to `move_to_position_tolerance_rad`.


## How I Tested
On TriFingerPro.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
