### PR TITLE
create_backend: Add argument for max_number_of_actions

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hpp
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hpp
@@ -471,6 +471,8 @@ public:
  * @param config_file_path  Path to the driver configuration file.
  * @param first_action_timeout  Duration for which the backend waits for the
  *     first action to arrive.  If exceeded, the backend shuts down.
+ * @param max_number_of_actions  Number of actions after which the backend
+ *     automatically shuts down.
  *
  * @return A RobotBackend instances with a driver of the specified type.
  */
@@ -478,7 +480,8 @@ template <typename Driver>
 typename Driver::Types::BackendPtr create_backend(
     typename Driver::Types::BaseDataPtr robot_data,
     const std::string &config_file_path,
-    const double first_action_timeout = std::numeric_limits<double>::infinity())
+    const double first_action_timeout = std::numeric_limits<double>::infinity(),
+    const uint32_t max_number_of_actions = 0)
 {
     constexpr double MAX_ACTION_DURATION_S = 0.003;
     constexpr double MAX_INTER_ACTION_DURATION_S = 0.005;
@@ -497,7 +500,11 @@ typename Driver::Types::BackendPtr create_backend(
 
     constexpr bool real_time_mode = true;
     auto backend = std::make_shared<typename Driver::Types::Backend>(
-        monitored_driver, robot_data, real_time_mode, first_action_timeout);
+        monitored_driver,
+        robot_data,
+        real_time_mode,
+        first_action_timeout,
+        max_number_of_actions);
     backend->set_max_action_repetitions(std::numeric_limits<uint32_t>::max());
 
     return backend;


### PR DESCRIPTION
## Description

Add argument `max_number_of_actions` to `create_backend`, so that the corresponding argument of the RobotBackend can be set via this function.

## How I Tested

On TriFingerPro.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] Related PR in robot_fingers is ready.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
