### PR TITLE
Add can_encoder_index_test application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################
 # set up the project #
 ######################
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1)
 
 project(blmc_robots)
 
@@ -9,7 +9,11 @@ project(blmc_robots)
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")
 endif()
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+# Specify C++ Standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # ensuring path to libraries are set during install
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,14 @@ build_programs(solo8ti_hardware_calibration solo8ti)
 build_programs(solo12_hardware_calibration solo12)
 build_programs(teststand_hardware_calibration teststand)
 
+add_executable(can_encoder_index_test
+  programs/can_encoder_index_test.cpp
+)
+target_link_libraries(can_encoder_index_test
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)
+
 ######################################################
 # Export the libraries in the devel folder of catkin #
 ######################################################

--- a/src/programs/can_encoder_index_test.cpp
+++ b/src/programs/can_encoder_index_test.cpp
@@ -8,123 +8,137 @@
  * \copyright Copyright (c) 2020 Max Planck Gesellschaft.
  */
 #include <array>
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <string>
-#include <cmath>
 
-#include <real_time_tools/thread.hpp>
 #include <real_time_tools/spinner.hpp>
+#include <real_time_tools/thread.hpp>
 
 #include <blmc_robots/blmc_joint_module.hpp>
 
-
-struct Params
+class EncoderIndexTester
 {
-    std::string can_port;
-    int motor_idx;
-    double torque;
+public:
+    static constexpr double torque_constant_NmpA = 0.02;
+    static constexpr double gear_ratio = 9.0;
+    static constexpr double max_current_A = 2.0;
+    static constexpr double one_motor_rotation_distance = 2.0 * M_PI / gear_ratio;
+
+    EncoderIndexTester(const std::string &can_port,
+                       int motor_index,
+                       double torque,
+                       unsigned int number_of_revolutions)
+        : torque_(torque)
+    {
+        std::cout << "CAN port: " << can_port << std::endl;
+        std::cout << "Motor Index: " << motor_index << std::endl;
+        std::cout << "Torque: " << torque << std::endl;
+
+        std::cout << "==============================" << std::endl;
+        std::cout << "Initialising..." << std::endl;
+
+        // setup can bus
+        auto can_bus = std::make_shared<blmc_drivers::CanBus>(can_port);
+
+        // set up motor board
+        auto motor_board =
+            std::make_shared<blmc_drivers::CanBusMotorBoard>(can_bus, 1000, 10);
+        motor_board->wait_until_ready();
+
+        std::shared_ptr<blmc_drivers::MotorInterface> motor =
+            std::make_shared<blmc_drivers::Motor>(motor_board, motor_index);
+
+        joint_module_ = std::make_unique<blmc_robots::BlmcJointModule>(
+            motor, torque_constant_NmpA, gear_ratio, 0, false, max_current_A);
+    }
+
+    void run()
+    {
+        std::cout << "Start moving with constant torque" << std::endl;
+        real_time_tools::Spinner spinner;
+        spinner.set_period(0.001);
+        double last_index_position = joint_module_->get_measured_index_angle();
+        unsigned int counter = 0;
+
+        // Do not print, rotate 100 times, count index ticks
+        // check after each rotation if tick was found
+
+        while (true)
+        {
+            joint_module_->set_torque(torque_);
+            joint_module_->send_torque();
+
+            double index_position = joint_module_->get_measured_index_angle();
+
+            if (!std::isnan(index_position) &&
+                index_position != last_index_position)
+            {
+                counter++;
+                double diff = index_position - last_index_position;
+                std::cout << "Found Encoder Index " << counter
+                          << ".\tPosition: " << index_position
+                          << ".\tDiff to last: " << diff << std::endl;
+
+                if (std::abs(std::abs(diff) - one_motor_rotation_distance) >
+                    0.01)
+                {
+                    std::cout << std::endl
+                              << "!!!! DISTANCE TO LAST INDEX DOES NOT MATCH "
+                                 "ONE REVOLUTION !!!!"
+                              << std::endl
+                              << std::endl;
+                    exit(2);
+                }
+
+                last_index_position = index_position;
+            }
+            spinner.spin();
+        }
+    }
+
+private:
+    double torque_;
+    std::unique_ptr<blmc_robots::BlmcJointModule> joint_module_;
 };
 
 
-void* foo(void *params)
+int main(int argc, char *argv[])
 {
-    const std::string can_port = ((Params*)params)->can_port;
-    const int motor_idx = ((Params*)params)->motor_idx;
-    const double torque = ((Params*)params)->torque;
-
-    std::cout << "CAN port: " << can_port << std::endl;
-    std::cout << "Motor Index: " << motor_idx << std::endl;
-    std::cout << "Torque: " << torque << std::endl;
-
-    std::cout << "==============================" << std::endl;
-    std::cout << "Initialising..." << std::endl;
-
-    // setup can bus
-    auto can_bus = std::make_shared<blmc_drivers::CanBus>(can_port);
-
-    // set up motor board
-    auto motor_board =
-        std::make_shared<blmc_drivers::CanBusMotorBoard>(can_bus, 1000, 10);
-    motor_board->wait_until_ready();
-
-    std::shared_ptr<blmc_drivers::MotorInterface> motor =
-        std::make_shared<blmc_drivers::Motor>(motor_board, motor_idx);
-
-    constexpr double torque_constant_NmpA = 0.02;
-    constexpr double gear_ratio = 9.0;
-    constexpr double max_current_A = 2.0;
-    constexpr double one_motor_rotation_distance = 2.0 * M_PI / gear_ratio;
-
-    blmc_robots::BlmcJointModule joint_module(
-        motor, torque_constant_NmpA, gear_ratio, 0, false, max_current_A);
-
-
-    std::cout << "Start moving with constant torque" << std::endl;
-    real_time_tools::Spinner spinner;
-    spinner.set_period(0.001);
-    double last_index_position = joint_module.get_measured_index_angle();
-    unsigned int counter = 0;
-    while (true)
-    {
-        joint_module.set_torque(torque);
-        joint_module.send_torque();
-
-        double index_position = joint_module.get_measured_index_angle();
-
-        if (!std::isnan(index_position) && index_position != last_index_position)
-        {
-            counter++;
-            double diff = index_position - last_index_position;
-            std::cout << "Found Encoder Index " << counter
-                << ".\tPosition: " << index_position
-                << ".\tDiff to last: " << diff
-                << std::endl;
-
-            if (std::abs(std::abs(diff) - one_motor_rotation_distance) > 0.01)
-            {
-                std::cout << std::endl
-                    << "!!!! DISTANCE TO LAST INDEX DOES NOT MATCH ONE REVOLUTION !!!!"
-                    << std::endl
-                    << std::endl;
-                exit(2);
-            }
-
-            last_index_position = index_position;
-        }
-        spinner.spin();
-    }
-
-    return nullptr;
-}
-
-
-int main(int argc, char* argv[])
-{
-    if (argc != 4)
+    if (argc != 5)
     {
         std::cout << "Invalid number of arguments." << std::endl;
-        std::cout << "Usage: " << argv[0] << " <can port> <motor index> <torque>"
-                  << std::endl;
+        std::cout
+            << "Usage: " << argv[0]
+            << " <can port> <motor index> <torque> <number of revolutions>"
+            << std::endl;
         return 1;
     }
 
-    Params params;
-    params.can_port = argv[1];
-    params.motor_idx = std::stoi(argv[2]);
-    params.torque = std::stod(argv[3]);
+    std::string can_port = argv[1];
+    int motor_index = std::stoi(argv[2]);
+    double torque = std::stod(argv[3]);
+    int num_revolutions = std::stoi(argv[4]);
 
-    if (params.motor_idx != 0 && params.motor_idx != 1)
+    if (motor_index != 0 && motor_index != 1)
     {
         std::cout << "Invalid motor index.  Only '0' and '1' are allowed."
                   << std::endl;
         return 1;
     }
 
-    real_time_tools::RealTimeThread thread;
-    thread.create_realtime_thread(&foo, &params);
+    EncoderIndexTester tester(can_port, motor_index, torque, num_revolutions);
 
-    while (true);
+    // run in real-time thread
+    real_time_tools::RealTimeThread thread;
+    thread.create_realtime_thread(
+        [](void *instance_pointer) {
+            ((EncoderIndexTester *)(instance_pointer))->run();
+            return (void *)nullptr;
+        },
+        &tester);
+    thread.join();
 
     return 0;
 }

--- a/src/programs/can_encoder_index_test.cpp
+++ b/src/programs/can_encoder_index_test.cpp
@@ -1,0 +1,130 @@
+/**
+ * \file
+ * \brief Simple test tool to check if the encoder index is detected.
+ *
+ * Runs a motor at a constant torque and prints a line whenever the encoder
+ * index is detected.
+ *
+ * \copyright Copyright (c) 2020 Max Planck Gesellschaft.
+ */
+#include <array>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <cmath>
+
+#include <real_time_tools/thread.hpp>
+#include <real_time_tools/spinner.hpp>
+
+#include <blmc_robots/blmc_joint_module.hpp>
+
+
+struct Params
+{
+    std::string can_port;
+    int motor_idx;
+    double torque;
+};
+
+
+void* foo(void *params)
+{
+    const std::string can_port = ((Params*)params)->can_port;
+    const int motor_idx = ((Params*)params)->motor_idx;
+    const double torque = ((Params*)params)->torque;
+
+    std::cout << "CAN port: " << can_port << std::endl;
+    std::cout << "Motor Index: " << motor_idx << std::endl;
+    std::cout << "Torque: " << torque << std::endl;
+
+    std::cout << "==============================" << std::endl;
+    std::cout << "Initialising..." << std::endl;
+
+    // setup can bus
+    auto can_bus = std::make_shared<blmc_drivers::CanBus>(can_port);
+
+    // set up motor board
+    auto motor_board =
+        std::make_shared<blmc_drivers::CanBusMotorBoard>(can_bus, 1000, 10);
+    motor_board->wait_until_ready();
+
+    std::shared_ptr<blmc_drivers::MotorInterface> motor =
+        std::make_shared<blmc_drivers::Motor>(motor_board, motor_idx);
+
+    constexpr double torque_constant_NmpA = 0.02;
+    constexpr double gear_ratio = 9.0;
+    constexpr double max_current_A = 2.0;
+    constexpr double one_motor_rotation_distance = 2.0 * M_PI / gear_ratio;
+
+    blmc_robots::BlmcJointModule joint_module(
+        motor, torque_constant_NmpA, gear_ratio, 0, false, max_current_A);
+
+
+    std::cout << "Start moving with constant torque" << std::endl;
+    real_time_tools::Spinner spinner;
+    spinner.set_period(0.001);
+    double last_index_position = joint_module.get_measured_index_angle();
+    unsigned int counter = 0;
+    while (true)
+    {
+        joint_module.set_torque(torque);
+        joint_module.send_torque();
+
+        double index_position = joint_module.get_measured_index_angle();
+
+        if (!std::isnan(index_position) && index_position != last_index_position)
+        {
+            counter++;
+            double diff = index_position - last_index_position;
+            std::cout << "Found Encoder Index " << counter
+                << ".\tPosition: " << index_position
+                << ".\tDiff to last: " << diff
+                << std::endl;
+
+            if (std::abs(std::abs(diff) - one_motor_rotation_distance) > 0.01)
+            {
+                std::cout << std::endl
+                    << "!!!! DISTANCE TO LAST INDEX DOES NOT MATCH ONE REVOLUTION !!!!"
+                    << std::endl
+                    << std::endl;
+                exit(2);
+            }
+
+            last_index_position = index_position;
+        }
+        spinner.spin();
+    }
+
+    return nullptr;
+}
+
+
+int main(int argc, char* argv[])
+{
+    if (argc != 4)
+    {
+        std::cout << "Invalid number of arguments." << std::endl;
+        std::cout << "Usage: " << argv[0] << " <can port> <motor index> <torque>"
+                  << std::endl;
+        return 1;
+    }
+
+    Params params;
+    params.can_port = argv[1];
+    params.motor_idx = std::stoi(argv[2]);
+    params.torque = std::stod(argv[3]);
+
+    if (params.motor_idx != 0 && params.motor_idx != 1)
+    {
+        std::cout << "Invalid motor index.  Only '0' and '1' are allowed."
+                  << std::endl;
+        return 1;
+    }
+
+    real_time_tools::RealTimeThread thread;
+    thread.create_realtime_thread(&foo, &params);
+
+    while (true);
+
+    return 0;
+}


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Small application to run a motor at constant torque and print a line every time the encoder index is observed.
If the position difference between two encoders differs from the expected distance of one motor revolution, an exception is thrown.

It takes as input the can port, the motor index (0 or 1) and a torque to move the motor, e.g.:

    can_encoder_index_test can0 1 0.2

I wrote this to have a tool to easily run a joint without much overhead and test if the encoder index is detected correctly.
As it is now, it is not really specific to any robot, however, parameters like torque constant and gear ratio are hard-coded.

There is one known issue: As the printing takes some time, this can lead to missed index ticks when the motor moves too fast, resulting in a false alert.

If you think this could be useful for yourself or others, I would suggest to merge it here.  Otherwise I will move it to robot_fingers. 


## How I Tested

By running it on a Finger robot.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
