### PR TITLE
Do not throw an exception if the shutdown fails

### DIFF
--- a/include/blmc_robots/n_joint_blmc_robot_driver.hxx
+++ b/include/blmc_robots/n_joint_blmc_robot_driver.hxx
@@ -384,8 +384,8 @@ void NJBRD::shutdown()
     {
         // TODO: report this somehow as this probably means that someone
         // needs to disentangle the robot manually.
-        throw std::runtime_error(
-            "Failed to reach rest position.  Robot may be blocked.");
+        std::cerr << "Failed to reach rest position.  Robot may be blocked."
+                  << std::endl;
     }
 }
 


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Do not throw an exception if the shutdown fails.
This can happen regularly when there is an object in the arena which is
blocking the path.  This is typically not a problem, though, so don't fail here.  If the robot is really stuck somewhere, this should be caught by the self-test which is executed after each job.


## How I Tested

Executed on TriFingerPro with cube in the arena.  Could not yet verify the blocking case, though.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
