### PR TITLE
Solo12: Add is_calibrating() method

### DIFF
--- a/include/blmc_robots/solo12.hpp
+++ b/include/blmc_robots/solo12.hpp
@@ -323,6 +323,15 @@ public:
         return false;
     }
 
+    /**
+     * @brief is_calibrating()
+     * @return Returns true if the calibration procedure is running right now.
+     */
+    bool is_calibrating()
+    {
+        return _is_calibrating;
+    }
+
 private:
     /**
      * Joint properties
@@ -486,6 +495,9 @@ private:
 
     /** @brief If the physical estop is pressed or not. */
     bool active_estop_;
+
+    /** @brief If the joint calibration is active or not. */
+    bool _is_calibrating;
 };
 
 }  // namespace blmc_robots

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -290,8 +290,13 @@ bool Solo12::calibrate(const Vector12d& home_offset_rad)
     profile_step_size_rad(3) *= -1;
     profile_step_size_rad(9) *= -1;
 
+    _is_calibrating = true;
+
     HomingReturnCode homing_return_code = joints_.execute_homing(
         search_distance_limit_rad, home_offset_rad, profile_step_size_rad);
+
+    _is_calibrating = false;
+
     if (homing_return_code == HomingReturnCode::FAILED)
     {
         return false;


### PR DESCRIPTION
Adds a new `is_calibrating` method for solo12. This is used in the safety code to disable the joint angles check while the calibration is running.