### PR TITLE
solo12: Initialize calibrate_request_ and use error from robot interface

### DIFF
--- a/include/blmc_robots/solo12.hpp
+++ b/include/blmc_robots/solo12.hpp
@@ -322,14 +322,7 @@ public:
      */
     bool has_error() const
     {
-        for (const auto& error_code : motor_board_errors_)
-        {
-            if (error_code != 0)
-            {
-                return true;
-            }
-        }
-        return false;
+        return robot_->HasError();
     }
 
     /**

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -69,6 +69,7 @@ Solo12::Solo12()
 
     // By default assume the estop is inactive.
     active_estop_= false;
+    calibrate_request_ = false;
 
     state_ = Solo12State::initial;
 }
@@ -254,6 +255,7 @@ void Solo12::send_target_joint_torque(
             {
                 calibrate_request_ = false;
                 state_ = Solo12State::calibrate;
+                _is_calibrating = true;
                 robot_->joints->SetZeroCommands();
             }
             robot_->SendCommand();
@@ -263,6 +265,7 @@ void Solo12::send_target_joint_torque(
             if (calib_ctrl_->Run())
             {
                 state_ = Solo12State::ready;
+                _is_calibrating = false;
             }
             robot_->SendCommand();
             break;
@@ -271,6 +274,7 @@ void Solo12::send_target_joint_torque(
 
 bool Solo12::calibrate(const Vector12d& home_offset_rad)
 {
+    printf("Solo12::calibrate called\n");
     Eigen::VectorXd hor = home_offset_rad;
     calib_ctrl_->UpdatePositionOffsets(hor);
     calibrate_request_ = true;


### PR DESCRIPTION
A small followup with fixes. It looks like without initializing the calibrate_request_ this variable was set to true, causing the robot to calibrate right away at startup.

In addition, I changed the `has_error` detection to use the error reporting from the ODCI robot interface.