### PR TITLE
Add powerboard measurements to Solo12 sensor data

### DIFF
--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -297,6 +297,37 @@ public:
         return imu_linear_acceleration_;
     }
 
+    /**
+     * @brief Get current [A] measurement from the power board.
+     *
+     * Will be zero if no power board is used.
+     */
+    float get_powerboard_current() const
+    {
+        return main_board_ptr_->powerboard_current();
+    }
+
+    /**
+     * @brief Get voltage [V] measurement from the power board.
+     *
+     * Will be zero if no power board is used.
+     */
+    float get_powerboard_voltage() const
+    {
+        return main_board_ptr_->powerboard_voltage();
+    }
+
+    /**
+     * @brief Get energy [J] consumed since start as measured by the power
+     * board.
+     *
+     * Will be zero if no power board is used.
+     */
+    float get_powerboard_energy() const
+    {
+        return main_board_ptr_->powerboard_energy();
+    }
+
     /*
      * Hardware Status
      */

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -304,6 +304,8 @@ public:
      */
     float get_powerboard_current() const
     {
+        // FIXME better get in acquire_sensors() so its in sync with other
+        // sensor data
         return main_board_ptr_->powerboard_current();
     }
 

--- a/src/dynamic_graph_manager/dgm_solo12.cpp
+++ b/src/dynamic_graph_manager/dgm_solo12.cpp
@@ -121,6 +121,9 @@ void DGMSolo12::get_sensors_to_map(dynamic_graph_manager::VectorDGMap& map)
     map.at("imu_gyroscope") = solo_.get_imu_gyroscope();
     map.at("imu_attitude") = solo_.get_imu_attitude();
     map.at("imu_linear_acceleration") = solo_.get_imu_linear_acceleration();
+    map.at("powerboard_current")[0] = solo_.get_powerboard_current();
+    map.at("powerboard_voltage")[0] = solo_.get_powerboard_voltage();
+    map.at("powerboard_energy")[0] = solo_.get_powerboard_energy();
 
     /**
      * Robot status.

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -1,8 +1,8 @@
 #include "solo/solo12.hpp"
 #include <cmath>
 #include <odri_control_interface/common.hpp>
-#include "solo/common_programs_header.hpp"
 #include "real_time_tools/spinner.hpp"
+#include "solo/common_programs_header.hpp"
 
 namespace solo
 {
@@ -79,8 +79,7 @@ void Solo12::initialize(const std::string& network_id,
     network_id_ = network_id;
 
     // Use a serial port to read slider values.
-    serial_reader_ =
-        std::make_shared<slider_box::SerialReader>(serial_port, 5);
+    serial_reader_ = std::make_shared<slider_box::SerialReader>(serial_port, 5);
 
     main_board_ptr_ = std::make_shared<MasterBoardInterface>(network_id_);
 
@@ -141,9 +140,12 @@ void Solo12::initialize(const std::string& network_id,
     calib_ctrl_ = std::make_shared<odri_control_interface::JointCalibrator>(
         joints_, directions, position_offsets, 5., 0.05, 1.0, 0.001);
 
+    auto powerboard =
+        std::make_shared<odri_control_interface::PowerBoard>(main_board_ptr_);
+
     // Define the robot.
     robot_ = std::make_shared<odri_control_interface::Robot>(
-        main_board_ptr_, joints_, imu_, calib_ctrl_);
+        main_board_ptr_, joints_, imu_, calib_ctrl_, powerboard);
 
     // Initialize the robot.
     robot_->Init();
@@ -279,7 +281,7 @@ void Solo12::send_target_joint_position(
 }
 
 void Solo12::send_target_joint_velocity(
-        const Eigen::Ref<Vector12d> target_joint_velocity)
+    const Eigen::Ref<Vector12d> target_joint_velocity)
 {
     robot_->joints->SetDesiredVelocities(target_joint_velocity);
 }
@@ -301,7 +303,7 @@ void Solo12::wait_until_ready()
     real_time_tools::Spinner spinner;
     spinner.set_period(0.001);
     static long int count_wait_until_ready = 0;
-    while(state_ != Solo12State::ready)
+    while (state_ != Solo12State::ready)
     {
         if (count_wait_until_ready % 200 == 0)
         {


### PR DESCRIPTION
## Description

https://github.com/open-dynamic-robot-initiative/master-board/pull/98 Adds support for a separate power board that provides measurements of current, voltage and energy.
This PR adds the corresponding values to the sensor data of Solo12.

## How I Tested

Running a dynamic_graph_head example and print the powerboard values there.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] https://github.com/open-dynamic-robot-initiative/master-board/pull/98
      (Note: It will still work without power board as well (the values will simply be zero if non is connected), but I am not sure if the firmware needs to be updated nonetheless to be compatible with SDK changes).
- [ ] Corresponding PR on odri_control_interface (PR not yet created).

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
