### PR TITLE
fix (solo12 calibration): Don't use banana port for sliderbox

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Apptainer
         uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v2
         with:
-          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/solo_user:latest
+          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/solo_bolt_user:latest
 
       - name: Build
         uses: open-dynamic-robot-initiative/trifinger-build-action/build@v2

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Apptainer
         uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v2
         with:
-          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/solo_user:latest
+          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/solo_bolt_user:latest
 
       - name: Build
         uses: open-dynamic-robot-initiative/trifinger-build-action/build@v2

--- a/src/programs/solo12_hardware_calibration.cpp
+++ b/src/programs/solo12_hardware_calibration.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
 
     // Initialize the shared content.
     SharedContent shared_content;
-    shared_content.robot.initialize(argv[1], "banana");
+    shared_content.robot.initialize(argv[1]);
     shared_content.sc_mutex.unlock();
     shared_content.print_home_offset = false;
 


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Due to changed behaviour of the slider box detection, this made the application crash.  Instead of passing a nonsensical value, simply rely on the default (auto-detection) here.

## How I Tested

On the test bench.